### PR TITLE
1) crypto.h- function signature Crypto_Config_MariaDB(), add extra in…

### DIFF
--- a/include/crypto.h
+++ b/include/crypto.h
@@ -71,17 +71,22 @@ Description:        sets the fields the struct SadbMariaDBConfig_t for required
                     7) char* ssl_cert - The path name of the server public key certificate file with .pem extension. 
                     8) char* ssl_key - The path name of the server private key file with .pem extension. 
                     9) char* ssl_ca - The path name of the Certificate Authority (CA) certificate file. 
-                    10) char* ssl_capath - Certificate Authority (CA) directory.      
+                    10) char* ssl_capath - Certificate Authority (CA) directory.    
+ *                  11) uint8_t tls_verify_server  - 0ptional parameter that corresponds to MySQL connection parameter MASTER_SSL_VERIFY_SERVER_CERT=1. Any 
+ *                  other value except 1 will be ignored. 
+ *                  12) char* tls_client_key_password - 0ptional parameter that corresponds to optional passcode that may be paired with ssl certs during cert creation. Not required.  
 Outputs:            status - int32
 References:         1) https://dev.mysql.com/doc/c-api/8.0/en/c-api-encrypted-
  *                      connections.html#c-api-enforcing-encrypted-connection
  *                  2) https://dev.mysql.com/doc/c-api/8.0/en/mysql-ssl-set.html
  *                  3) https://www.xuchao.org/docs/mysql/connectors-apis.html#c-api-encrypted-connections
+ *                  4) https://dev.mysql.com/doc/refman/5.7/en/replication-solutions-encrypted-connections.html
 Example call:        
 Note:               MySQL server MUST be configured for encrypted connections:
  *                  https://dev.mysql.com/doc/refman/5.7/en/using-encrypted-connections.html
 ==========================================================*/
-extern int32_t Crypto_Config_MariaDB(char* mysql_username, char* mysql_password, char* mysql_hostname, char* mysql_database, uint16_t mysql_port, uint8_t encrypted_connection, char* ssl_cert, char* ssl_key, char* ssl_ca, char* ssl_capath);
+extern int32_t Crypto_Config_MariaDB(char* mysql_username, char* mysql_password, char* mysql_hostname, char* mysql_database, uint16_t mysql_port, uint8_t encrypted_connection, char* ssl_cert, char* ssl_key, char* ssl_ca, char* ssl_capath, 
+        uint8_t tls_verify_server, char* tls_client_key_password);
 extern int32_t Crypto_Config_Kmc_Crypto_Service(char *protocol, char *kmc_crypto_hostname, uint16_t kmc_crypto_port, char *kmc_crypto_app_uri, char *mtls_client_cert_path, char *mtls_client_cert_type,
                                                 char *mtls_client_key_path,char *mtls_client_key_pass, char *mtls_ca_bundle, char *mtls_ca_path,
                                                 char *mtls_issuer_cert, uint8_t ignore_ssl_hostname_validation);

--- a/include/crypto_config_structs.h
+++ b/include/crypto_config_structs.h
@@ -147,6 +147,9 @@ typedef struct
     char* ssl_key; 
     char* ssl_ca; 
     char* ssl_capath;
+    uint8_t tls_verifyserver;
+    char* tls_clientkeypassword;
+
 } SadbMariaDBConfig_t;
 #define SADB_MARIADB_CONFIG_SIZE (sizeof(SadbMariaDBConfig_t))
 

--- a/src/src_main/crypto_config.c
+++ b/src/src_main/crypto_config.c
@@ -259,7 +259,8 @@ int32_t Crypto_Config_CryptoLib(uint8_t sadb_type, uint8_t cryptography_type, ui
  * @return int32: Success/Failure 
  **/
 /*set parameters for an encrypted TLS connection*/
-int32_t Crypto_Config_MariaDB(char* mysql_username, char* mysql_password, char* mysql_hostname, char* mysql_database, uint16_t mysql_port, uint8_t encrypted_connection, char* ssl_cert, char* ssl_key, char* ssl_ca, char* ssl_capath)
+int32_t Crypto_Config_MariaDB(char* mysql_username, char* mysql_password, char* mysql_hostname, char* mysql_database, uint16_t mysql_port, uint8_t encrypted_connection, char* ssl_cert, char* ssl_key, char* ssl_ca, char* ssl_capath, 
+uint8_t tls_verify_server, char* tls_client_key_password)
 {
     int32_t status = CRYPTO_LIB_ERROR;
     sadb_mariadb_config = (SadbMariaDBConfig_t*)calloc(1, SADB_MARIADB_CONFIG_SIZE);
@@ -275,7 +276,9 @@ int32_t Crypto_Config_MariaDB(char* mysql_username, char* mysql_password, char* 
         sadb_mariadb_config->ssl_cert = ssl_cert; 
         sadb_mariadb_config->ssl_key = ssl_key; 
         sadb_mariadb_config->ssl_ca = ssl_ca; 
-        sadb_mariadb_config->ssl_capath = ssl_capath; 
+        sadb_mariadb_config->ssl_capath = ssl_capath;
+        sadb_mariadb_config->tls_verifyserver = tls_verify_server; 
+        sadb_mariadb_config->tls_clientkeypassword = tls_client_key_password;
         /*end - encrypted connection related parameters*/
         status = CRYPTO_LIB_SUCCESS; 
     }

--- a/src/src_mysql/sadb_routine_mariadb.template.c
+++ b/src/src_mysql/sadb_routine_mariadb.template.c
@@ -96,61 +96,100 @@ static int32_t sadb_config(void)
     return CRYPTO_LIB_SUCCESS;
 }
 
+/*Note:For TLS & mTLS connections MySQL server MUST be configured for encrypted 
+connections: https://dev.mysql.com/doc/refman/5.7/en/using-encrypted-connections.html*/
 static int32_t sadb_init(void) {
     int32_t status = CRYPTO_LIB_ERROR;
     if (NULL != sadb_mariadb_config) {
         con = mysql_init(NULL);
-        //if encrypted connection (TLS) connection 
-        if (sadb_mariadb_config->encrypted_connection == 1 || 
-            sadb_mariadb_config->encrypted_connection == 2) {
-            /*Note:MySQL server MUST be configured for encrypted connections:
- *          https://dev.mysql.com/doc/refman/5.7/en/using-encrypted-connections.html*/
-            mysql_ssl_set(con,
-            sadb_mariadb_config->ssl_key,
-            sadb_mariadb_config->ssl_cert,
-            sadb_mariadb_config->ssl_ca,
-            sadb_mariadb_config->ssl_capath, NULL);
-            /*Based documentation mysql_ssl_set() always returns 0.
-            Therefore successful connections can only be checked
-            via subsequent call to mysql_real_connect()*/
-            //if NULL is returned then there is an error, else success
-            if (mysql_real_connect(con, sadb_mariadb_config->mysql_hostname,
-                    sadb_mariadb_config->mysql_username,
-                    sadb_mariadb_config->mysql_password,
-                    sadb_mariadb_config->mysql_database,
-                    sadb_mariadb_config->mysql_port, NULL, 0) == NULL) {
-                //0,NULL,0 are port number, unix socket, client flag
-                finish_with_error(con, SADB_MARIADB_CONNECTION_FAILED);
-                status = CRYPTO_LIB_ERROR;
-            } else {
-                status = CRYPTO_LIB_SUCCESS;
-                if (status==CRYPTO_LIB_SUCCESS) {
-                    printf("sadb_init Using an encrypted connection \n");
+        if (NULL != con) {
+            mysql_ssl_set(con, sadb_mariadb_config->ssl_key,
+                    sadb_mariadb_config->ssl_cert,
+                    sadb_mariadb_config->ssl_ca,
+                    sadb_mariadb_config->ssl_capath, NULL);
+            //if encrypted connection (TLS) connection. No need for SSL Key 
+            if (sadb_mariadb_config->encrypted_connection == 1) {
+                //extra parameters 
+                if (sadb_mariadb_config->tls_verifyserver ==1)
+                {
+                    mysql_options4(con, MYSQL_OPT_CONNECT_ATTR_ADD, "MASTER_SSL_VERIFY_SERVER_CERT", "1");
                 }
-            }
-        }//end if TLS connection  
-            //else regular username & password connection 
-        else {
-            //if NULL is returned then there is an error, else success
-            if (mysql_real_connect(con, sadb_mariadb_config->mysql_hostname,
-                    sadb_mariadb_config->mysql_username,
-                    sadb_mariadb_config->mysql_password,
-                    sadb_mariadb_config->mysql_database,
-                    sadb_mariadb_config->mysql_port, NULL, 0) == NULL) {
-                //0,NULL,0 are port number, unix socket, client flag
-                finish_with_error(con, SADB_MARIADB_CONNECTION_FAILED);
-                status = CRYPTO_LIB_ERROR;
-            } else {
-                status = CRYPTO_LIB_SUCCESS;
-                if (status==CRYPTO_LIB_SUCCESS) {
-                    printf("sadb_init Using plain socket connection \n");
+                if (NULL!=sadb_mariadb_config->tls_clientkeypassword)
+                {
+                    mysql_options4(con, MYSQL_OPT_CONNECT_ATTR_ADD, "ssl-passphrase", sadb_mariadb_config->tls_clientkeypassword);
                 }
+                /*Based documentation mysql_ssl_set() always returns 0.
+                Therefore successful connections can only be checked
+                via subsequent call to mysql_real_connect()*/
+                //if NULL is returned then there is an error, else success
+                if (mysql_real_connect(con, sadb_mariadb_config->mysql_hostname,
+                        sadb_mariadb_config->mysql_username,
+                        sadb_mariadb_config->mysql_password,
+                        sadb_mariadb_config->mysql_database,
+                        sadb_mariadb_config->mysql_port, NULL, 0) == NULL) {
+                    //0,NULL,0 are port number, unix socket, client flag
+                    finish_with_error(con, SADB_MARIADB_CONNECTION_FAILED);
+                    status = CRYPTO_LIB_ERROR;
+                } else {
+                    status = CRYPTO_LIB_SUCCESS;
+                    if (status == CRYPTO_LIB_SUCCESS) {
+                        printf("sadb_init Using an encrypted connection \n");
+                    }
+                }
+            }//end if TLS connection 
+                //if mTLS connection. No need password. 
+            else if (sadb_mariadb_config->encrypted_connection == 2) {
+                //if NULL is returned then there is an error, else success
+                //extra parameters 
+                if (sadb_mariadb_config->tls_verifyserver ==1)
+                {
+                    mysql_options4(con, MYSQL_OPT_CONNECT_ATTR_ADD, "MASTER_SSL_VERIFY_SERVER_CERT", "1");
+                }
+                if (NULL!=sadb_mariadb_config->tls_clientkeypassword)
+                {
+                    mysql_options4(con, MYSQL_OPT_CONNECT_ATTR_ADD, "ssl-passphrase", sadb_mariadb_config->tls_clientkeypassword);
+                }
+                if (mysql_real_connect(con, sadb_mariadb_config->mysql_hostname,
+                        sadb_mariadb_config->mysql_username,
+                        NULL,
+                        sadb_mariadb_config->mysql_database,
+                        sadb_mariadb_config->mysql_port, NULL, 0) == NULL) {
+                    //0,NULL,0 are port number, unix socket, client flag
+                    finish_with_error(con, SADB_MARIADB_CONNECTION_FAILED);
+                    status = CRYPTO_LIB_ERROR;
+                } else {
+                    status = CRYPTO_LIB_SUCCESS;
+                    if (status == CRYPTO_LIB_SUCCESS) {
+                        printf("sadb_init Using an encrypted connection \n");
+                    }
+                }
+            }//end if mTLS connection 
+                //else regular username & password connection 
+            else {
+                //if NULL is returned then there is an error, else success
+                if (mysql_real_connect(con, sadb_mariadb_config->mysql_hostname,
+                        sadb_mariadb_config->mysql_username,
+                        sadb_mariadb_config->mysql_password,
+                        sadb_mariadb_config->mysql_database,
+                        sadb_mariadb_config->mysql_port, NULL, 0) == NULL) {
+                    //0,NULL,0 are port number, unix socket, client flag
+                    finish_with_error(con, SADB_MARIADB_CONNECTION_FAILED);
+                    status = CRYPTO_LIB_ERROR;
+                } else {
+                    status = CRYPTO_LIB_SUCCESS;
+                    if (status == CRYPTO_LIB_SUCCESS) {
+                        printf("sadb_init Using plain socket connection \n");
+                    }
+                }
+            }//end regular password 
+        } else {
+            //error
+            fprintf(stderr, "Error, sadb_init() MySQL API function mysql_init() returned a connection object that is NULL\n");
+        }
 
-            }
-        }//end regular password 
     }
     return status;
-}
+}//end int32_t sadb_init()
 
 static int32_t sadb_close(void)
 {

--- a/util/src_util/ut_crypto_config.c
+++ b/util/src_util/ut_crypto_config.c
@@ -159,7 +159,9 @@ UTEST(CRYPTO_CONFIG, CRYPTO_CONFIG_MDB)
     char* ssl_key = "NONE";
     char* ssl_ca = "NONE";
     char* ssl_capath = "NONE";
-    status = Crypto_Config_MariaDB(mysql_username, mysql_password, mysql_hostname, mysql_database, mysql_port, enc_conn, ssl_cert, ssl_key, ssl_ca, ssl_capath);
+    uint8_t verify_server = 0; 
+    char* client_key_password = NULL;
+    status = Crypto_Config_MariaDB(mysql_username, mysql_password, mysql_hostname, mysql_database, mysql_port, enc_conn, ssl_cert, ssl_key, ssl_ca, ssl_capath, verify_server,client_key_password);
     ASSERT_EQ(CRYPTO_LIB_SUCCESS, status);
 }
 

--- a/util/src_util/ut_kmc_crypto.c
+++ b/util/src_util/ut_kmc_crypto.c
@@ -37,7 +37,7 @@ UTEST(KMC_CRYPTO, HAPPY_PATH_APPLY_SEC_ENC_AND_AUTH)
     Crypto_Config_CryptoLib(SADB_TYPE_MARIADB, CRYPTOGRAPHY_TYPE_KMCCRYPTO, CRYPTO_TC_CREATE_FECF_TRUE, TC_PROCESS_SDLS_PDUS_FALSE, TC_NO_PUS_HDR,
                             TC_IGNORE_SA_STATE_FALSE, TC_IGNORE_ANTI_REPLAY_TRUE, TC_UNIQUE_SA_PER_MAP_ID_FALSE,
                             TC_CHECK_FECF_TRUE, 0x3F);
-    Crypto_Config_MariaDB("sadb_user", "sadb_password", "localhost","sadb", 3306, CRYPTO_FALSE, NULL, NULL, NULL, NULL);
+    Crypto_Config_MariaDB("sadb_user", "sadb_password", "localhost","sadb", 3306, CRYPTO_FALSE, NULL, NULL, NULL, NULL,0,NULL);
     Crypto_Config_Kmc_Crypto_Service("https", "asec-cmdenc-srv1.jpl.nasa.gov", 8443, "crypto-service", "/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/local-test-cert.pem", "PEM","/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/local-test-key.pem",NULL,"/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/ammos-ca-bundle.crt", NULL, NULL, CRYPTO_FALSE);
     Crypto_Config_Add_Gvcid_Managed_Parameter(0, 0x002C, 0, TC_HAS_FECF, TC_NO_SEGMENT_HDRS);
     Crypto_Config_Add_Gvcid_Managed_Parameter(0, 0x002C, 1, TC_HAS_FECF, TC_NO_SEGMENT_HDRS);
@@ -87,7 +87,7 @@ UTEST(KMC_CRYPTO, HAPPY_PATH_APPLY_SEC_ENC_ONLY)
     Crypto_Config_CryptoLib(SADB_TYPE_MARIADB, CRYPTOGRAPHY_TYPE_KMCCRYPTO, CRYPTO_TC_CREATE_FECF_TRUE, TC_PROCESS_SDLS_PDUS_FALSE, TC_NO_PUS_HDR,
                             TC_IGNORE_SA_STATE_FALSE, TC_IGNORE_ANTI_REPLAY_TRUE, TC_UNIQUE_SA_PER_MAP_ID_FALSE,
                             TC_CHECK_FECF_TRUE, 0x3F);
-    Crypto_Config_MariaDB("sadb_user", "sadb_password", "localhost","sadb", 3306, CRYPTO_FALSE, NULL, NULL, NULL, NULL);
+    Crypto_Config_MariaDB("sadb_user", "sadb_password", "localhost","sadb", 3306, CRYPTO_FALSE, NULL, NULL, NULL, NULL,0,NULL);
     Crypto_Config_Kmc_Crypto_Service("https", "asec-cmdenc-srv1.jpl.nasa.gov", 8443, "crypto-service", "/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/local-test-cert.pem", "PEM","/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/local-test-key.pem",NULL,"/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/ammos-ca-bundle.crt", NULL, NULL, CRYPTO_FALSE);
     Crypto_Config_Add_Gvcid_Managed_Parameter(0, 0x002C, 0, TC_HAS_FECF, TC_NO_SEGMENT_HDRS);
     Crypto_Config_Add_Gvcid_Managed_Parameter(0, 0x002C, 1, TC_HAS_FECF, TC_NO_SEGMENT_HDRS);
@@ -137,7 +137,7 @@ UTEST(KMC_CRYPTO, HAPPY_PATH_APPLY_SEC_AUTH_ONLY)
     Crypto_Config_CryptoLib(SADB_TYPE_MARIADB, CRYPTOGRAPHY_TYPE_KMCCRYPTO, CRYPTO_TC_CREATE_FECF_TRUE, TC_PROCESS_SDLS_PDUS_FALSE, TC_NO_PUS_HDR,
                             TC_IGNORE_SA_STATE_FALSE, TC_IGNORE_ANTI_REPLAY_TRUE, TC_UNIQUE_SA_PER_MAP_ID_FALSE,
                             TC_CHECK_FECF_TRUE, 0x3F);
-    Crypto_Config_MariaDB("sadb_user", "sadb_password", "localhost","sadb", 3306, CRYPTO_FALSE, NULL, NULL, NULL, NULL);
+    Crypto_Config_MariaDB("sadb_user", "sadb_password", "localhost","sadb", 3306, CRYPTO_FALSE, NULL, NULL, NULL, NULL,0,NULL);
     Crypto_Config_Kmc_Crypto_Service("https", "asec-cmdenc-srv1.jpl.nasa.gov", 8443, "crypto-service", "/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/local-test-cert.pem", "PEM","/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/local-test-key.pem",NULL,"/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/ammos-ca-bundle.crt", NULL, NULL, CRYPTO_FALSE);
     Crypto_Config_Add_Gvcid_Managed_Parameter(0, 0x002C, 0, TC_HAS_FECF, TC_NO_SEGMENT_HDRS);
     Crypto_Config_Add_Gvcid_Managed_Parameter(0, 0x002C, 1, TC_HAS_FECF, TC_NO_SEGMENT_HDRS);
@@ -188,7 +188,7 @@ UTEST(KMC_CRYPTO, HAPPY_PATH_PROCESS_SEC_ENC_AND_AUTH)
     Crypto_Config_CryptoLib(SADB_TYPE_MARIADB, CRYPTOGRAPHY_TYPE_KMCCRYPTO, CRYPTO_TC_CREATE_FECF_TRUE, TC_PROCESS_SDLS_PDUS_FALSE, TC_NO_PUS_HDR,
                             TC_IGNORE_SA_STATE_FALSE, TC_IGNORE_ANTI_REPLAY_TRUE, TC_UNIQUE_SA_PER_MAP_ID_FALSE,
                             TC_CHECK_FECF_TRUE, 0x3F);
-    Crypto_Config_MariaDB("sadb_user", "sadb_password", "localhost","sadb", 3306, CRYPTO_FALSE, NULL, NULL, NULL, NULL);
+    Crypto_Config_MariaDB("sadb_user", "sadb_password", "localhost","sadb", 3306, CRYPTO_FALSE, NULL, NULL, NULL, NULL,0,NULL);
     Crypto_Config_Kmc_Crypto_Service("https", "asec-cmdenc-srv1.jpl.nasa.gov", 8443, "crypto-service", "/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/local-test-cert.pem", "PEM","/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/local-test-key.pem",NULL,"/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/ammos-ca-bundle.crt", NULL, NULL, CRYPTO_FALSE);
     Crypto_Config_Add_Gvcid_Managed_Parameter(0, 0x002C, 0, TC_HAS_FECF, TC_NO_SEGMENT_HDRS);
     Crypto_Config_Add_Gvcid_Managed_Parameter(0, 0x002C, 1, TC_HAS_FECF, TC_NO_SEGMENT_HDRS);
@@ -247,7 +247,7 @@ UTEST(KMC_CRYPTO, HAPPY_PATH_PROCESS_SEC_ENC_ONLY)
     Crypto_Config_CryptoLib(SADB_TYPE_MARIADB, CRYPTOGRAPHY_TYPE_KMCCRYPTO, CRYPTO_TC_CREATE_FECF_TRUE, TC_PROCESS_SDLS_PDUS_FALSE, TC_NO_PUS_HDR,
                             TC_IGNORE_SA_STATE_FALSE, TC_IGNORE_ANTI_REPLAY_TRUE, TC_UNIQUE_SA_PER_MAP_ID_FALSE,
                             TC_CHECK_FECF_TRUE, 0x3F);
-    Crypto_Config_MariaDB("sadb_user", "sadb_password", "localhost","sadb", 3306, CRYPTO_FALSE, NULL, NULL, NULL, NULL);
+    Crypto_Config_MariaDB("sadb_user", "sadb_password", "localhost","sadb", 3306, CRYPTO_FALSE, NULL, NULL, NULL, NULL,0,NULL);
     Crypto_Config_Kmc_Crypto_Service("https", "asec-cmdenc-srv1.jpl.nasa.gov", 8443, "crypto-service", "/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/local-test-cert.pem", "PEM","/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/local-test-key.pem",NULL,"/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/ammos-ca-bundle.crt", NULL, NULL, CRYPTO_FALSE);
     Crypto_Config_Add_Gvcid_Managed_Parameter(0, 0x002C, 0, TC_HAS_FECF, TC_NO_SEGMENT_HDRS);
     Crypto_Config_Add_Gvcid_Managed_Parameter(0, 0x002C, 1, TC_HAS_FECF, TC_NO_SEGMENT_HDRS);
@@ -307,7 +307,7 @@ UTEST(KMC_CRYPTO, HAPPY_PATH_PROCESS_SEC_AUTH_ONLY)
     Crypto_Config_CryptoLib(SADB_TYPE_MARIADB, CRYPTOGRAPHY_TYPE_KMCCRYPTO, CRYPTO_TC_CREATE_FECF_TRUE, TC_PROCESS_SDLS_PDUS_FALSE, TC_NO_PUS_HDR,
                             TC_IGNORE_SA_STATE_FALSE, TC_IGNORE_ANTI_REPLAY_TRUE, TC_UNIQUE_SA_PER_MAP_ID_FALSE,
                             TC_CHECK_FECF_TRUE, 0x3F);
-    Crypto_Config_MariaDB("sadb_user", "sadb_password", "localhost","sadb", 3306, CRYPTO_FALSE, NULL, NULL, NULL, NULL);
+    Crypto_Config_MariaDB("sadb_user", "sadb_password", "localhost","sadb", 3306, CRYPTO_FALSE, NULL, NULL, NULL, NULL,0,NULL);
     Crypto_Config_Kmc_Crypto_Service("https", "asec-cmdenc-srv1.jpl.nasa.gov", 8443, "crypto-service", "/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/local-test-cert.pem", "PEM","/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/local-test-key.pem",NULL,"/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/ammos-ca-bundle.crt", NULL, NULL, CRYPTO_FALSE);
     Crypto_Config_Add_Gvcid_Managed_Parameter(0, 0x002C, 0, TC_HAS_FECF, TC_NO_SEGMENT_HDRS);
     Crypto_Config_Add_Gvcid_Managed_Parameter(0, 0x002C, 1, TC_HAS_FECF, TC_NO_SEGMENT_HDRS);

--- a/util/src_util/ut_kmc_crypto_aes_cmac.c
+++ b/util/src_util/ut_kmc_crypto_aes_cmac.c
@@ -37,7 +37,7 @@ UTEST(KMC_CRYPTO, HAPPY_PATH_APPLY_SEC_CMAC_AUTH_ONLY)
     Crypto_Config_CryptoLib(SADB_TYPE_MARIADB, CRYPTOGRAPHY_TYPE_KMCCRYPTO, CRYPTO_TC_CREATE_FECF_TRUE, TC_PROCESS_SDLS_PDUS_FALSE, TC_NO_PUS_HDR,
                             TC_IGNORE_SA_STATE_FALSE, TC_IGNORE_ANTI_REPLAY_TRUE, TC_UNIQUE_SA_PER_MAP_ID_FALSE,
                             TC_CHECK_FECF_TRUE, 0x3F);
-    Crypto_Config_MariaDB("sadb_user", "sadb_password", "localhost","sadb", 3306, CRYPTO_FALSE, NULL, NULL, NULL, NULL);
+    Crypto_Config_MariaDB("sadb_user", "sadb_password", "localhost","sadb", 3306, CRYPTO_FALSE, NULL, NULL, NULL, NULL,0,NULL);
     Crypto_Config_Kmc_Crypto_Service("https", "asec-cmdenc-srv1.jpl.nasa.gov", 8443, "crypto-service", "/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/local-test-cert.pem", "PEM","/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/local-test-key.pem",NULL,"/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/ammos-ca-bundle.crt", NULL, NULL, CRYPTO_FALSE);
     Crypto_Config_Add_Gvcid_Managed_Parameter(0, 0x002C, 7, TC_HAS_FECF, TC_NO_SEGMENT_HDRS);
     int32_t status = Crypto_Init();
@@ -85,7 +85,7 @@ UTEST(KMC_CRYPTO, HAPPY_PATH_PROCESS_SEC_CMAC_AUTH_ONLY)
     Crypto_Config_CryptoLib(SADB_TYPE_MARIADB, CRYPTOGRAPHY_TYPE_KMCCRYPTO, CRYPTO_TC_CREATE_FECF_TRUE, TC_PROCESS_SDLS_PDUS_FALSE, TC_NO_PUS_HDR,
                             TC_IGNORE_SA_STATE_FALSE, TC_IGNORE_ANTI_REPLAY_TRUE, TC_UNIQUE_SA_PER_MAP_ID_FALSE,
                             TC_CHECK_FECF_TRUE, 0x3F);
-    Crypto_Config_MariaDB("sadb_user", "sadb_password", "localhost","sadb", 3306, CRYPTO_FALSE, NULL, NULL, NULL, NULL);
+    Crypto_Config_MariaDB("sadb_user", "sadb_password", "localhost","sadb", 3306, CRYPTO_FALSE, NULL, NULL, NULL, NULL,0,NULL);
     Crypto_Config_Kmc_Crypto_Service("https", "asec-cmdenc-srv1.jpl.nasa.gov", 8443, "crypto-service", "/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/local-test-cert.pem", "PEM","/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/local-test-key.pem",NULL,"/home/isaleh/git/KMC/CryptoLib-IbraheemYSaleh/util/etc/ammos-ca-bundle.crt", NULL, NULL, CRYPTO_FALSE);
     Crypto_Config_Add_Gvcid_Managed_Parameter(0, 0x002C, 7, TC_HAS_FECF, TC_NO_SEGMENT_HDRS);
     int32_t status = Crypto_Init();

--- a/util/src_util/ut_mysql_m_tls_connection.c
+++ b/util/src_util/ut_mysql_m_tls_connection.c
@@ -68,7 +68,6 @@ mysql -u testuser2 -h asec-cmdenc-dev2.jpl.nasa.gov --ssl-ca=/etc/pki/tls/certs/
 Password: 2 way TLS or mTLS does not require a password.  
 However using the MySQL's C API*/
 UTEST(MARIA_DB_CONNECTION_TESTS, TLS_TEST) {
-    
     printf("START mariadb connection, TLS test() \n");
     int status = 0;
     /*connection input parameters. 
@@ -80,19 +79,25 @@ UTEST(MARIA_DB_CONNECTION_TESTS, TLS_TEST) {
     uint16_t mysql_port = 3306;
     /*encrypted_connection = 1 means we want to attempt a TLS encrypted connection.*/
     uint8_t encrypted_connection = 1;
-    char* ssl_cert = "/etc/pki/tls/certs/ammos-server-cert.pem";
-    char* ssl_key = "/etc/pki/tls/private/ammos-server-key.pem";
+    char* ssl_cert = "/etc/pki/tls/certs/local-test-cert.pem";
+    char* ssl_key = "/etc/pki/tls/private/local-test-key.pem";
     char* ssl_ca = "/etc/pki/tls/certs/ammos-ca-bundle.crt";
     char* ssl_capath = "/etc/pki/tls/certs/";
+    uint8_t verify_server = 0;
+    char* client_key_password = NULL; 
+    //uint8_t ssl_verify_server_cert = 1;
     /*set configuration params*/
-    status = Crypto_Config_MariaDB(mysql_username, password, mysql_hostname, mysql_database, mysql_port, encrypted_connection, ssl_cert, ssl_key, ssl_ca, ssl_capath);
+    status = Crypto_Config_MariaDB(mysql_username, password, mysql_hostname, mysql_database, mysql_port, encrypted_connection, ssl_cert, ssl_key, ssl_ca, ssl_capath,verify_server,client_key_password);
     ASSERT_EQ(CRYPTO_LIB_SUCCESS, status);
     /*Prepare SADB type from config*/
     status = Crypto_Init_Unit_Test_For_DB();
+    SadbRoutine sadb_routine = get_sadb_routine_mariadb();
     ASSERT_EQ(CRYPTO_LIB_SUCCESS, status);
     printf("END mariadb connection, TLS test() status:%d \n", status);
     printf("START mariadb connection, mTLS test() \n");
     status = 0;
+    //close the connection to avoid a duplicate connection error when running the test multiple times. 
+    sadb_routine->sadb_close(); 
     /*connection input parameters. 
      Note: username, pass, and paths may differ on your system*/
     mysql_username = "testuser2";
@@ -107,12 +112,14 @@ UTEST(MARIA_DB_CONNECTION_TESTS, TLS_TEST) {
     ssl_ca = "/etc/pki/tls/certs/ammos-ca-bundle.crt";
     ssl_capath = "/etc/pki/tls/certs/";
     /*set configuration params*/
-    status = Crypto_Config_MariaDB(mysql_username, password, mysql_hostname, mysql_database, mysql_port, encrypted_connection, ssl_cert, ssl_key, ssl_ca, ssl_capath);
+    status = Crypto_Config_MariaDB(mysql_username, password, mysql_hostname, mysql_database, mysql_port, encrypted_connection, ssl_cert, ssl_key, ssl_ca, ssl_capath,verify_server,client_key_password);
     ASSERT_EQ(CRYPTO_LIB_SUCCESS, status);
     /*Prepare SADB type from config*/
     status = Crypto_Init_Unit_Test_For_DB();
     ASSERT_EQ(CRYPTO_LIB_SUCCESS, status);
     printf("END mariadb connection, mTLS test() status:%d \n", status);
+    //close the connection to avoid a duplicate connection error when running the test multiple times. 
+    sadb_routine->sadb_close(); 
     
 }
 


### PR DESCRIPTION
1) crypto.h- function signature Crypto_Config_MariaDB(), add extra input params uint8_t tls_verify_server &  tls_client_key_password

2) crypto_config.c Implementation of Crypto_Config_MariaDB(), add extra input params uint8_t tls_verify_server &  tls_client_key_password

3) crypto_config_structs.h - added params uint8_t tls_verify_server &  tls_client_key_password

4) ut_mysql_m_tls_connection.c - 
	i) modified the test in order to pass input params uint8_t tls_verify_server &  tls_client_key_password
	ii) closed connection after test to allow mutiple test runs without errors. 

5) sadb_routine_mariadb.template.c
	i) used mysql_options4() option 
Based MySQL C API docs: https://dev.mysql.com/doc/refman/5.7/en/replication-solutions-encrypted-connections.html

	in order to pass in extra connection parameters. 

6) ut_kmc_crypto_aes_cmac.c , ut_kmc_crypto.c - passed in uint8_t tls_verify_server &  tls_client_key_password

7) ut_mysql_tls_connection - redundant unity test, tls is already covered in ut_mysql_m_tls_connection.c

Cheers!