### PR TITLE
AMMOSGH-121: Make verbose outputs only print in DEBUG builds

### DIFF
--- a/src/src_cryptography/src_kmc_crypto_service/cryptography_interface_kmc_crypto_service.template.c
+++ b/src/src_cryptography/src_kmc_crypto_service/cryptography_interface_kmc_crypto_service.template.c
@@ -1866,14 +1866,17 @@ static int32_t get_cam_sso_token()
 #endif
     curl_easy_setopt(curl_cam,CURLOPT_URL,kerberos_endpoint_final);
 
-    memory_read* chunk_read = (memory_read*) calloc(1,MEMORY_READ_SIZE);;
+    memory_read* chunk_read = (memory_read*) calloc(1,MEMORY_READ_SIZE);
+    memory_write* chunk_write = (memory_write*) calloc(1,MEMORY_WRITE_SIZE);
 
     /* Configure CURL for POST */
     curl_easy_setopt(curl_cam, CURLOPT_POST, 1L);
     /* send all data to this function  */
     curl_easy_setopt(curl_cam, CURLOPT_READFUNCTION, read_callback);
+    curl_easy_setopt(curl_cam,CURLOPT_WRITEFUNCTION, write_callback);
     /* we pass our 'chunk' struct to the callback function */
     curl_easy_setopt(curl_cam, CURLOPT_READDATA, chunk_read);
+    curl_easy_setopt(curl_cam,CURLOPT_WRITEDATA,chunk_write);
     curl_easy_setopt(curl_cam, CURLOPT_COOKIEJAR, cam_config->cookie_file_path);
 
     res = curl_easy_perform(curl_cam);
@@ -1905,6 +1908,7 @@ static int32_t get_cam_sso_token()
     curl_easy_cleanup(curl_cam);
     free(kerberos_endpoint_final);
     free(chunk_read);
+    free(chunk_write);
     return status;
 }
 

--- a/src/src_main/crypto_config.c
+++ b/src/src_main/crypto_config.c
@@ -174,9 +174,11 @@ int32_t Crypto_Init(void)
         Crypto_Calc_CRC_Init_Table();
 
         // cFS Standard Initialized Message
+#ifdef DEBUG
         printf(KBLU "Crypto Lib Intialized.  Version %d.%d.%d.%d\n" RESET, CRYPTO_LIB_MAJOR_VERSION,
                CRYPTO_LIB_MINOR_VERSION, CRYPTO_LIB_REVISION, CRYPTO_LIB_MISSION_REV);
-        }
+#endif
+    }
     else
     {
         printf(KBLU "Error, Crypto Lib NOT Intialized, sadb_init() returned error:%d.  Version .%d.%d.%d\n" RESET, CRYPTO_LIB_MAJOR_VERSION,


### PR DESCRIPTION
This addresses the following bug tickets:
https://github.jpl.nasa.gov/ASEC/AMMOS-CryptoLib/issues/121
https://github.jpl.nasa.gov/ASEC/AMMOS-CryptoLib/issues/122