### PR TITLE
Remove unnecessary return; from last line of void functions

### DIFF
--- a/src/src_main/crypto_tm.c
+++ b/src/src_main/crypto_tm.c
@@ -467,8 +467,6 @@ void Crypto_TM_updatePDU(uint8_t* ingest, int len_ingest)
     }
 #endif
 #endif
-
-    return;
 }
 
 /**

--- a/util/src_util/et_dt_validation.c
+++ b/util/src_util/et_dt_validation.c
@@ -99,7 +99,6 @@ void python_cmac(char* data, char* key, uint8_t** expected, long *expected_lengt
     char* temp_expected = PyBytes_AsString(pValue);
     *expected = (uint8_t* )malloc(sizeof(uint8_t) * (int)*expected_length);
     memcpy(*expected, temp_expected, (int)*expected_length);
-    return;
 }
 
 /**
@@ -130,7 +129,6 @@ void python_auth_encryption(char* data, char* key, char* iv, char* header, char*
     char* temp_expected = PyBytes_AsString(pValue);
     *expected = (uint8_t* )malloc(sizeof(uint8_t) * (int)*expected_length);
     memcpy(*expected, temp_expected, (int)*expected_length);
-    return;
 }
 
 /**


### PR DESCRIPTION
Noticed a few cases of unnecessary `return;` statements on the last line of void functions, which are not required.

Improves code consistency (most void functions in CryptoLib do not include a `return;` on the final line).

No impact on code logic.