### PR TITLE
#177 Fix - per SpicyDLL - solves possibility of sa NULL dereference

### DIFF
--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -812,6 +812,10 @@ int32_t Crypto_Check_Anti_Replay(SecurityAssociation_t* sa_ptr, uint8_t* arsn, u
     int8_t ARSN_VALID = -1;
 
     // Check for NULL pointers
+    if (sa_ptr == NULL) // #177 - Modification made per suggestion of 'Spicydll' - prevents null dereference
+    {
+        return CRYPTO_LIB_ERR_NULL_SA;
+    }
     if (arsn == NULL && sa_ptr->arsn_len > 0)
     {
         return CRYPTO_LIB_ERR_NULL_ARSN;
@@ -820,10 +824,7 @@ int32_t Crypto_Check_Anti_Replay(SecurityAssociation_t* sa_ptr, uint8_t* arsn, u
     {
         return CRYPTO_LIB_ERR_NULL_IV;
     }
-    if (sa_ptr == NULL)
-    {
-        return CRYPTO_LIB_ERR_NULL_SA;
-    }
+    
     // If sequence number field is greater than zero, check for replay
     if (sa_ptr->shsnf_len > 0)
     {


### PR DESCRIPTION
Improvement suggested by 'SpicyDLL'

A null check was too late in a chain of checks, and would allow for checks against possibly null values.  This has been modified and fixed.