### PR TITLE
[nasa/cryptolib#211] Modify sadb_get_sa_from_spi.  Unnecessary NULL

### DIFF
--- a/src/sa/internal/sa_interface_inmemory.template.c
+++ b/src/sa/internal/sa_interface_inmemory.template.c
@@ -439,16 +439,13 @@ static int32_t sa_close(void)
 static int32_t sa_get_from_spi(uint16_t spi, SecurityAssociation_t** security_association)
 {
     int32_t status = CRYPTO_LIB_SUCCESS;
-    if (sa == NULL)
-    {
-        return CRYPTO_LIB_ERR_NO_INIT;
-    }
     *security_association = &sa[spi];
-    if (sa[spi].iv == NULL && (sa[spi].shivf_len > 0) && crypto_config.cryptography_type != CRYPTOGRAPHY_TYPE_KMCCRYPTO)
+    if ((sa[spi].iv == NULL) && (sa[spi].shivf_len > 0) && crypto_config.cryptography_type != CRYPTOGRAPHY_TYPE_KMCCRYPTO)
     {
         return CRYPTO_LIB_ERR_NULL_IV;
     } // Must have IV if doing encryption or authentication
-    if (sa[spi].abm == NULL && sa[spi].ast)
+
+    if ((sa[spi].abm_len == 0) && sa[spi].ast)
     {
         return CRYPTO_LIB_ERR_NULL_ABM;
     } // Must have abm if doing authentication


### PR DESCRIPTION
#184 
The unnecessary reference to a null SA has been removed.

The function has been reworked to work better (more correctly) with the new internal SA setup.

The previous memory leak referenced by this issue has been removed already.  We no longer calloc the arsn or iv within the internal sa in this manner.

Consider when reviewing this, if we should modify the character pointers within our SAs to be a set array length.  (This would also aid in more easily saving those values in the upcoming save/load capabilities.