### PR TITLE
[nasa/cryptolib#241] Resolve convert SA character pointers to arrays.  

### DIFF
--- a/include/crypto.h
+++ b/include/crypto.h
@@ -238,6 +238,10 @@ int32_t Crypto_User_ModifyVCID(void);
 // SA Save Functions
 int32_t sa_perform_save(SecurityAssociation_t* sa);
 
+// Clean REF
+void clean_ekref(SecurityAssociation_t* sa);
+void clean_akref(SecurityAssociation_t* sa);
+
 // Determine Payload Data Unit
 int32_t Crypto_Process_Extended_Procedure_Pdu(TC_t* tc_sdls_processed_frame, uint8_t* ingest);
 int32_t Crypto_PDU(uint8_t* ingest, TC_t* tc_frame);

--- a/include/crypto_config.h
+++ b/include/crypto_config.h
@@ -116,6 +116,7 @@
 #define ENABLED 1
 #define IV_SIZE 16   /* TM IV size bytes */
 #define IV_SIZE_TC 4 /* TC IV size bytes */
+#define REF_SIZE 250
 #define OCF_SIZE 4
 #define MAC_SIZE 16           /* bytes */
 #define FECF_SIZE 2

--- a/include/crypto_structs.h
+++ b/include/crypto_structs.h
@@ -52,8 +52,8 @@ typedef struct
     uint16_t spi;  // Security Parameter Index
     uint16_t ekid; // Encryption Key ID  (Used with numerically indexed keystores, EG inmemory keyring)
     uint16_t akid; // Authentication Key ID
-    char*    ek_ref; // Encryption Key Reference (Used with string-referenced keystores,EG-PKCS12 keystores, KMC crypto)
-    char*    ak_ref; // Authentication Key Reference (Used with string-referenced keystores,EG-PKCS12 keystores, KMC crypto)
+    char ek_ref[REF_SIZE]; // Encryption Key Reference (Used with string-referenced keystores,EG-PKCS12 keystores, KMC crypto)
+    char ak_ref[REF_SIZE]; // Authentication Key Reference (Used with string-referenced keystores,EG-PKCS12 keystores, KMC crypto)
     uint8_t sa_state : 2;
     crypto_gvcid_t gvcid_blk;
     // crypto_gvcid_t gvcid_tm_blk[NUM_GVCID];

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -65,6 +65,32 @@ uint16_t crc16Table[256];
 */
 
 /**
+ * @brief Function: clean_ekref
+ * Looks up cipher suite ID and determines if it's an AEAD algorithm. Returns 1 if true, 0 if false;
+ * @param sa: SecurityAssocation_t*
+ **/
+void clean_ekref(SecurityAssociation_t* sa)
+{
+    for(int y = 0; y < REF_SIZE; y++)
+    {
+        sa->ek_ref[y] = '\0';
+    }
+}
+
+/**
+ * @brief Function: clean_akref
+ * Looks up cipher suite ID and determines if it's an AEAD algorithm. Returns 1 if true, 0 if false;
+ * @param sa: SecurityAssocation_t*
+ **/
+void clean_akref(SecurityAssociation_t* sa)
+{
+    for(int y = 0; y < REF_SIZE; y++)
+    {
+        sa->ak_ref[y] = '\0';
+    }
+}
+
+/**
  * @brief Function: Crypto_Is_AEAD_Algorithm
  * Looks up cipher suite ID and determines if it's an AEAD algorithm. Returns 1 if true, 0 if false;
  * @param cipher_suite_id: uint32

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -66,7 +66,7 @@ uint16_t crc16Table[256];
 
 /**
  * @brief Function: clean_ekref
- * Looks up cipher suite ID and determines if it's an AEAD algorithm. Returns 1 if true, 0 if false;
+ * Null terminates the entire array for EKREF
  * @param sa: SecurityAssocation_t*
  **/
 void clean_ekref(SecurityAssociation_t* sa)
@@ -79,7 +79,7 @@ void clean_ekref(SecurityAssociation_t* sa)
 
 /**
  * @brief Function: clean_akref
- * Looks up cipher suite ID and determines if it's an AEAD algorithm. Returns 1 if true, 0 if false;
+ * Null terminates the entire array for AKREF
  * @param sa: SecurityAssocation_t*
  **/
 void clean_akref(SecurityAssociation_t* sa)

--- a/src/core/crypto_print.c
+++ b/src/core/crypto_print.c
@@ -209,9 +209,9 @@ void Crypto_saPrint(SecurityAssociation_t* sa)
         }
     }
     printf("\t ekid       = %d \n", sa->ekid);
-    //printf("\t ek_ref     = %s \n", sa->ek_ref);
+    printf("\t ek_ref     = %s \n", sa->ek_ref);
     printf("\t akid       = %d \n", sa->akid);
-    //printf("\t ak_ref     = %s \n", sa->ak_ref);
+    printf("\t ak_ref     = %s \n", sa->ak_ref);
     printf("\t iv_len     = %d \n", sa->iv_len);
     if (sa->iv_len > 0)
     {

--- a/src/core/crypto_tc.c
+++ b/src/core/crypto_tc.c
@@ -1593,8 +1593,10 @@ int32_t Crypto_TC_Check_IV_ARSN(SecurityAssociation_t* sa_ptr,TC_t* tc_sdls_proc
     {
         if (crypto_config.sa_type == SA_TYPE_MARIADB)
         {
-            //if (sa_ptr->ek_ref != NULL)
-            //    free(sa_ptr->ek_ref);
+            if (sa_ptr->ek_ref[0] != '\0')
+                clean_ekref(sa_ptr);
+            if (sa_ptr->ak_ref[0] != '\0')
+                clean_akref(sa_ptr);
             free(sa_ptr);
         }
     }

--- a/src/core/crypto_tc.c
+++ b/src/core/crypto_tc.c
@@ -1593,8 +1593,8 @@ int32_t Crypto_TC_Check_IV_ARSN(SecurityAssociation_t* sa_ptr,TC_t* tc_sdls_proc
     {
         if (crypto_config.sa_type == SA_TYPE_MARIADB)
         {
-            if (sa_ptr->ek_ref != NULL)
-                free(sa_ptr->ek_ref);
+            //if (sa_ptr->ek_ref != NULL)
+            //    free(sa_ptr->ek_ref);
             free(sa_ptr);
         }
     }

--- a/src/crypto/kmc/cryptography_interface_kmc_crypto_service.template.c
+++ b/src/crypto/kmc/cryptography_interface_kmc_crypto_service.template.c
@@ -762,7 +762,7 @@ static int32_t cryptography_authenticate(uint8_t* data_out, size_t len_data_out,
         return CRYPTO_LIB_ERR_NULL_BUFFER;
     }
 
-    if(sa_ptr->ak_ref == NULL)
+    if(sa_ptr->ak_ref[0] == '\0')
     {
         status = CRYPTOGRAHPY_KMC_NULL_AUTHENTICATION_KEY_REFERENCE_IN_SA;
         return status;
@@ -995,7 +995,7 @@ static int32_t cryptography_validate_authentication(uint8_t* data_out, size_t le
     Crypto_hexprint(mac,mac_size);
 #endif
 
-    if(sa_ptr->ak_ref == NULL)
+    if(sa_ptr->ak_ref[0] == '\0')
     {
         status = CRYPTOGRAHPY_KMC_NULL_AUTHENTICATION_KEY_REFERENCE_IN_SA;
         return status;

--- a/src/crypto/kmc/cryptography_interface_kmc_crypto_service.template.c
+++ b/src/crypto/kmc/cryptography_interface_kmc_crypto_service.template.c
@@ -320,7 +320,7 @@ static int32_t cryptography_encrypt(uint8_t* data_out, size_t len_data_out,
     printf("IV Base64 URL Encoded: %s\n",iv_base64);
 #endif
 
-    if(sa_ptr->ek_ref == NULL)
+    if(sa_ptr->ek_ref[0] == '\0')
     {
         status = CRYPTOGRAHPY_KMC_NULL_ENCRYPTION_KEY_REFERENCE_IN_SA;
         return status;
@@ -565,7 +565,7 @@ static int32_t cryptography_decrypt(uint8_t* data_out, size_t len_data_out,
 #endif
 
 
-    if(sa_ptr->ek_ref == NULL)
+    if(sa_ptr->ek_ref[0] == '\0')
     {
         status = CRYPTOGRAHPY_KMC_NULL_ENCRYPTION_KEY_REFERENCE_IN_SA;
         return status;
@@ -1177,7 +1177,7 @@ static int32_t cryptography_aead_encrypt(uint8_t* data_out, size_t len_data_out,
     printf("IV Base64 URL Encoded: %s\n",iv_base64);
 #endif
 
-    if(sa_ptr->ek_ref == NULL)
+    if(sa_ptr->ek_ref[0] == '\0')
     {
         status = CRYPTOGRAHPY_KMC_NULL_ENCRYPTION_KEY_REFERENCE_IN_SA;
         free(iv_base64);
@@ -1553,7 +1553,7 @@ static int32_t cryptography_aead_decrypt(uint8_t* data_out, size_t len_data_out,
 #endif
 
 
-    if(sa_ptr->ek_ref == NULL)
+    if(sa_ptr->ek_ref[0] == '\0')
     {
         status = CRYPTOGRAHPY_KMC_NULL_ENCRYPTION_KEY_REFERENCE_IN_SA;
         return status;

--- a/src/sa/internal/sa_interface_inmemory.template.c
+++ b/src/sa/internal/sa_interface_inmemory.template.c
@@ -124,9 +124,7 @@ void update_sa_from_ptr(SecurityAssociation_t* sa_ptr)
     sa[location].ekid = sa_ptr->ekid;
     sa[location].akid = sa_ptr->akid;
     memcpy(sa[location].ek_ref, sa_ptr->ek_ref, REF_SIZE);
-    //sa[location].ek_ref = sa_ptr->ek_ref;
     memcpy(sa[location].ak_ref, sa_ptr->ak_ref, REF_SIZE);
-    //sa[location].ak_ref = sa_ptr->ak_ref;
     sa[location].sa_state = sa_ptr->sa_state;
     sa[location].gvcid_blk = sa_ptr->gvcid_blk;
     sa[location].lpid = sa_ptr->lpid;
@@ -142,7 +140,6 @@ void update_sa_from_ptr(SecurityAssociation_t* sa_ptr)
     {
         sa[location].iv[i] = sa_ptr->iv[i];
     }
-    //sa[location].iv[0] = sa_ptr->iv;
     sa[location].iv_len = sa_ptr->iv_len;
     sa[location].acs_len = sa_ptr->acs_len;
     sa[location].acs = sa_ptr->acs;
@@ -151,13 +148,11 @@ void update_sa_from_ptr(SecurityAssociation_t* sa_ptr)
     {
         sa[location].abm[i] = sa_ptr->abm[i];
     }
-    //sa[location].abm[0] = sa_ptr->abm;
     sa[location].arsn_len = sa_ptr->arsn_len;
     for(int i = 0; i<sa_ptr->arsn_len; i++)
     {
         sa[location].arsn[i] = sa_ptr->arsn[i];
     }
-    //sa[location].arsn[0] = sa_ptr->arsn;
     sa[location].arsnw_len = sa_ptr->arsnw_len;
     sa[location].arsnw = sa_ptr->arsnw;
 }
@@ -416,7 +411,6 @@ void sa_populate(void)
     sa[10].gvcid_blk.mapid = TYPE_TC;
     char ek_ref_string[20] = "kmc/test/key130";
     memcpy(sa[10].ek_ref, ek_ref_string, strlen(ek_ref_string)); 
-    //sa[10].ek_ref = (char*) "kmc/test/key130";
 
     // SA 11 - KEYED;  ARSNW:5; AES-GCM; IV:00...00; IV-len:12; MAC-len:16; Key-ID: 130
     // SA 11 VC0/1 is now 4-VC0, 7-VC1
@@ -440,7 +434,6 @@ void sa_populate(void)
     sa[11].gvcid_blk.scid = SCID & 0x3FF;
     sa[11].gvcid_blk.vcid = 0;
     sa[11].gvcid_blk.mapid = TYPE_TC;
-    //sa[11].ek_ref = (char*) "kmc/test/key130";
     memcpy(sa[11].ek_ref, ek_ref_string, strlen(ek_ref_string));
 
     // SA 12 - TM CLEAR MODE

--- a/src/sa/internal/sa_interface_inmemory.template.c
+++ b/src/sa/internal/sa_interface_inmemory.template.c
@@ -123,8 +123,10 @@ void update_sa_from_ptr(SecurityAssociation_t* sa_ptr)
     sa[location].spi = sa_ptr->spi;
     sa[location].ekid = sa_ptr->ekid;
     sa[location].akid = sa_ptr->akid;
-    sa[location].ek_ref = sa_ptr->ek_ref;
-    sa[location].ak_ref = sa_ptr->ak_ref;
+    memcpy(sa[location].ek_ref, sa_ptr->ek_ref, REF_SIZE);
+    //sa[location].ek_ref = sa_ptr->ek_ref;
+    memcpy(sa[location].ak_ref, sa_ptr->ak_ref, REF_SIZE);
+    //sa[location].ak_ref = sa_ptr->ak_ref;
     sa[location].sa_state = sa_ptr->sa_state;
     sa[location].gvcid_blk = sa_ptr->gvcid_blk;
     sa[location].lpid = sa_ptr->lpid;
@@ -412,7 +414,9 @@ void sa_populate(void)
     sa[10].gvcid_blk.scid = 0x002C;
     sa[10].gvcid_blk.vcid = 1;
     sa[10].gvcid_blk.mapid = TYPE_TC;
-    sa[10].ek_ref = (char*) "kmc/test/key130";
+    char ek_ref_string[20] = "kmc/test/key130";
+    memcpy(sa[10].ek_ref, ek_ref_string, strlen(ek_ref_string)); 
+    //sa[10].ek_ref = (char*) "kmc/test/key130";
 
     // SA 11 - KEYED;  ARSNW:5; AES-GCM; IV:00...00; IV-len:12; MAC-len:16; Key-ID: 130
     // SA 11 VC0/1 is now 4-VC0, 7-VC1
@@ -436,7 +440,8 @@ void sa_populate(void)
     sa[11].gvcid_blk.scid = SCID & 0x3FF;
     sa[11].gvcid_blk.vcid = 0;
     sa[11].gvcid_blk.mapid = TYPE_TC;
-    sa[11].ek_ref = (char*) "kmc/test/key130";
+    //sa[11].ek_ref = (char*) "kmc/test/key130";
+    memcpy(sa[11].ek_ref, ek_ref_string, strlen(ek_ref_string));
 
     // SA 12 - TM CLEAR MODE
     // SA 12
@@ -611,6 +616,11 @@ int32_t sa_init(void)
             for (int y = 0; y < ABM_SIZE; y++)
             {
                 sa[x].abm[y] = 0;
+            }
+            for( int y = 0; y < REF_SIZE; y++)
+            {
+                sa[x].ek_ref[y] = '\0';
+                sa[x].ak_ref[y] = '\0';
             }
             sa[x].abm_len = 0;
             sa[x].acs_len = 0;

--- a/src/sa/mariadb/sa_interface_mariadb.template.c
+++ b/src/sa/mariadb/sa_interface_mariadb.template.c
@@ -379,7 +379,6 @@ static int32_t parse_sa_from_mysql_query(char* query, SecurityAssociation_t** se
                 } else // Cryptography Type KMC Crypto Service with PKCS12 String Key References
                 {
                     sa->ekid = 0;
-                    //sa->ek_ref = malloc((strlen(row[i])+1) * sizeof(char));
                     memcpy(sa->ek_ref, row[i], strlen(row[i])+1);
                 }
                 continue;
@@ -391,7 +390,6 @@ static int32_t parse_sa_from_mysql_query(char* query, SecurityAssociation_t** se
                     sa->akid = atoi(row[i]);
                 } else // Cryptography Type KMC Crypto Service with PKCS12 String Key References
                 {
-                    //sa->ak_ref = malloc((strlen(row[i])+1) * sizeof(char));
                     memcpy(sa->ak_ref, row[i], strlen(row[i])+1);
                 }
                 continue;

--- a/src/sa/mariadb/sa_interface_mariadb.template.c
+++ b/src/sa/mariadb/sa_interface_mariadb.template.c
@@ -252,11 +252,14 @@ static int32_t sa_save_sa(SecurityAssociation_t* sa)
     // todo - if query fails, need to push failure message to error stack instead of just return code.
 
     // We free the allocated SA memory in the save function.
-    if (sa->ek_ref != NULL)
-        free(sa->ek_ref);
-    if (sa->ak_ref != NULL)
-        free(sa->ak_ref);
+    if (sa->ek_ref[0] != '\0')
+        clean_ekref(sa);
+        //free(sa->ek_ref);
+    if (sa->ak_ref[0] != '\0')
+        clean_akref(sa);
+        //free(sa->ak_ref);
     free(sa);
+
     return status;
 }
 // Security Association Utility Functions
@@ -376,7 +379,7 @@ static int32_t parse_sa_from_mysql_query(char* query, SecurityAssociation_t** se
                 } else // Cryptography Type KMC Crypto Service with PKCS12 String Key References
                 {
                     sa->ekid = 0;
-                    sa->ek_ref = malloc((strlen(row[i])+1) * sizeof(char));
+                    //sa->ek_ref = malloc((strlen(row[i])+1) * sizeof(char));
                     memcpy(sa->ek_ref, row[i], strlen(row[i])+1);
                 }
                 continue;
@@ -388,7 +391,7 @@ static int32_t parse_sa_from_mysql_query(char* query, SecurityAssociation_t** se
                     sa->akid = atoi(row[i]);
                 } else // Cryptography Type KMC Crypto Service with PKCS12 String Key References
                 {
-                    sa->ak_ref = malloc((strlen(row[i])+1) * sizeof(char));
+                    //sa->ak_ref = malloc((strlen(row[i])+1) * sizeof(char));
                     memcpy(sa->ak_ref, row[i], strlen(row[i])+1);
                 }
                 continue;

--- a/src/sa/mariadb/sa_interface_mariadb.template.c
+++ b/src/sa/mariadb/sa_interface_mariadb.template.c
@@ -254,10 +254,8 @@ static int32_t sa_save_sa(SecurityAssociation_t* sa)
     // We free the allocated SA memory in the save function.
     if (sa->ek_ref[0] != '\0')
         clean_ekref(sa);
-        //free(sa->ek_ref);
     if (sa->ak_ref[0] != '\0')
         clean_akref(sa);
-        //free(sa->ak_ref);
     free(sa);
 
     return status;

--- a/test/kmc/ut_mariadb.c
+++ b/test/kmc/ut_mariadb.c
@@ -42,10 +42,8 @@ void cleanup_sa(SecurityAssociation_t* test_association)
 {
     if (test_association->ek_ref[0] != '\0')
         clean_ek_ref(test_association);
-        // free(test_association->ek_ref);
     if (test_association->ak_ref[0] != '\0')
         clean_ak_ref(test_association);
-        // free(test_association->ak_ref);
     
     free(test_association);
 }

--- a/test/kmc/ut_mariadb.c
+++ b/test/kmc/ut_mariadb.c
@@ -40,10 +40,12 @@
 
 void cleanup_sa(SecurityAssociation_t* test_association)
 {
-    if (test_association->ek_ref != NULL)
-        free(test_association->ek_ref);
-    if (test_association->ak_ref != NULL)
-        free(test_association->ak_ref);
+    if (test_association->ek_ref[0] != '\0')
+        clean_ek_ref(test_association);
+        // free(test_association->ek_ref);
+    if (test_association->ak_ref[0] != '\0')
+        clean_ak_ref(test_association);
+        // free(test_association->ak_ref);
     
     free(test_association);
 }

--- a/test/unit/ut_sa_save.c
+++ b/test/unit/ut_sa_save.c
@@ -46,8 +46,11 @@ UTEST(SA_SAVE, VERIFY_INTERNAL)
     ASSERT_EQ(test_association->spi, 4);
     ASSERT_EQ(test_association->ekid, 130);
     ASSERT_EQ(test_association->akid, 4);
-    //test_association->ek_ref = sa_ptr->ek_ref;
-    //test_association->ak_ref = sa_ptr->ak_ref;
+    int str_cmp_output = 0;
+    str_cmp_output = strcmp(test_association->ek_ref, "");
+    ASSERT_EQ(0, str_cmp_output);
+    str_cmp_output = strcmp(test_association->ak_ref, "");
+    ASSERT_EQ(0, str_cmp_output);
     ASSERT_EQ(test_association->sa_state, SA_OPERATIONAL);
     ASSERT_EQ(test_association->gvcid_blk.tfvn, 0);
     ASSERT_EQ(test_association->gvcid_blk.scid, (SCID & 0x3FF));
@@ -122,6 +125,8 @@ UTEST(SA_SAVE, INTERNAL_DEFAULT_PASS_1)
     test_association->shivf_len = 6;
     test_association->iv_len = 12;
     test_association->arsn_len = 0;
+    strcpy(test_association->ek_ref, "TEST_EK_REF");
+    strcpy(test_association->ak_ref, "TEST_AK_REF");
     memcpy(test_association->iv + (test_association->iv_len - test_association->shivf_len), new_iv_b, new_iv_len);
 
     return_val =
@@ -168,8 +173,16 @@ UTEST(SA_SAVE, VERIFY_DEFAULT_PASS_1_SAVE)
     ASSERT_EQ(test_association->spi, 4);
     ASSERT_EQ(test_association->ekid, 130);
     ASSERT_EQ(test_association->akid, 4);
-    //test_association->ek_ref = sa_ptr->ek_ref;
-    //test_association->ak_ref = sa_ptr->ak_ref;
+    int str_cmp_output = 0;
+    str_cmp_output = strcmp(test_association->ek_ref, "TEST_EK_REF");
+    ASSERT_EQ(0, str_cmp_output);
+    str_cmp_output = strcmp(test_association->ek_ref, "TEST_EK_REF_BAD");
+    ASSERT_NE(0, str_cmp_output);
+    str_cmp_output = strcmp(test_association->ak_ref, "TEST_AK_REF");
+    ASSERT_EQ(0, str_cmp_output);
+    str_cmp_output = strcmp(test_association->ak_ref, "TEST_AK_REF_BAD");
+    ASSERT_NE(0, str_cmp_output);
+    
     ASSERT_EQ(test_association->sa_state, SA_OPERATIONAL);
     ASSERT_EQ(test_association->gvcid_blk.tfvn, 0);
     ASSERT_EQ(test_association->gvcid_blk.scid, (SCID & 0x3FF));
@@ -254,6 +267,8 @@ UTEST(SA_SAVE, SAVE_PASS_1)
     test_association->shivf_len = 6;
     test_association->iv_len = 12;
     test_association->arsn_len = 0;
+    clean_akref(test_association);
+    clean_ekref(test_association);
     memcpy(test_association->iv + (test_association->iv_len - test_association->shivf_len), new_iv_b, new_iv_len);
 
     return_val =
@@ -300,8 +315,15 @@ UTEST(SA_SAVE, VERIFY_SAVE_PASS_1_SAVE)
     ASSERT_EQ(test_association->spi, 4);
     ASSERT_EQ(test_association->ekid, 130);
     ASSERT_EQ(test_association->akid, 4);
-    //test_association->ek_ref = sa_ptr->ek_ref;
-    //test_association->ak_ref = sa_ptr->ak_ref;
+    int str_cmp_output = 0;
+    str_cmp_output = strcmp(test_association->ek_ref, "");
+    ASSERT_EQ(0, str_cmp_output);
+    str_cmp_output = strcmp(test_association->ek_ref, "TEST_EK_REF_BAD");
+    ASSERT_NE(0, str_cmp_output);
+    str_cmp_output = strcmp(test_association->ak_ref, "");
+    ASSERT_EQ(0, str_cmp_output);
+    str_cmp_output = strcmp(test_association->ak_ref, "TEST_AK_REF_BAD");
+    ASSERT_NE(0, str_cmp_output);
     ASSERT_EQ(test_association->sa_state, SA_OPERATIONAL);
     ASSERT_EQ(test_association->gvcid_blk.tfvn, 0);
     ASSERT_EQ(test_association->gvcid_blk.scid, (SCID & 0x3FF));


### PR DESCRIPTION
New Tests
Tests Updated
Allocations Removed
Frees Removed

New Clear ek_ref/ak_ref functionality

Currently set to 250 character Max.