### PR TITLE
Update Key Mapping #198

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ option(SYSTEM_INSTALL "SystemInstall" OFF)
 option(TEST "Test" OFF)
 option(TEST_ENC "Tests - Encryption" OFF)
 option(SA_FILE "Save Security Association to File" OFF)
+option(KEY_VALIDATION "Validate existance of key duplication" OFF)
 
 OPTION(KMC_MDB_RH "KMC-MDB-RedHat-Integration-Testing" OFF) #Disabled by default, enable with: -DKMC_MDB_RH=ON
 OPTION(KMC_MDB_DB "KMC-MDB-Debian-Integration-Testing" OFF) #Disabled by default, enable with: -DKMC_MDB_DB=ON
@@ -108,6 +109,10 @@ endif()
 
 if(SA_FILE)
     add_definitions(-DSA_FILE)
+endif()
+
+if(KEY_VALIDATION)
+    add_definitions(-DKEY_VALIDATION)
 endif()
 
 if(DEBUG)

--- a/include/crypto_error.h
+++ b/include/crypto_error.h
@@ -123,6 +123,7 @@
 #define CRYPTO_LIB_ERR_INVALID_SA_SERVICE_TYPE (-51)
 #define CRYPTO_LIB_ERR_FAIL_SA_SAVE (-52)
 #define CRYPTO_LIB_ERR_FAIL_SA_LOAD (-53)
+#define CRYPTO_LIB_ERR_KEY_VALIDATION (-54)
 
 extern char *crypto_enum_errlist_core[];
 extern char *crypto_enum_errlist_config[];

--- a/src/core/crypto_error.c
+++ b/src/core/crypto_error.c
@@ -74,7 +74,8 @@ char *crypto_enum_errlist_core[] =
         (char*) "CRYPTO_LIB_ERR_TC_ENUM_USED_FOR_AOS_CONFIG",
         (char*) "CRYPTO_LIB_ERR_INVALID_SA_SERVICE_TYPE",
         (char*) "CRYPTO_LIB_ERR_FAIL_SA_SAVE",
-        (char*) "CRYPTO_LIB_ERR_FAIL_SA_LOAD", 
+        (char*) "CRYPTO_LIB_ERR_FAIL_SA_LOAD",
+        (char*) "CRYPTO_LIB_ERR_KEY_VALIDATION", 
 };
 
 char *crypto_enum_errlist_config[] =

--- a/src/sa/internal/sa_interface_inmemory.template.c
+++ b/src/sa/internal/sa_interface_inmemory.template.c
@@ -544,6 +544,51 @@ void sa_populate(void)
     sa_perform_save(&sa[0]);
 }
 
+/**
+ * @brief Function Key_Validation()
+ * Validates the use of a single key per encryption type per SA
+ * At most an SA can contain 2 unique Keys.  These my not be utilized in another SA
+ */
+int32_t key_validation(void)
+{
+    int32_t status = CRYPTO_LIB_SUCCESS;
+    int i = 0;
+    int j = 0;
+    for(i = 0; i < NUM_SA; i++)
+    {
+        uint16_t i_ekid = sa[i].ekid;
+        uint16_t i_akid = sa[i].akid;
+        
+        if(i_ekid == i_akid)
+        {
+            status = CRYPTO_LIB_ERR_KEY_VALIDATION;
+#ifdef DEBUG
+            printf(KRED "SA Key Validation FAILURE!\n");
+            printf("Key Duplication: SA #%d, EKID: %d, AKID: %d\n", i, i_ekid, i_akid);
+            printf("\n"RESET);
+#endif 
+            break;
+        }
+
+        for(j = i+1; j < NUM_SA; j++)
+        {
+            uint16_t j_ekid = sa[j].ekid;
+            uint16_t j_akid = sa[j].akid;
+        
+            if((i_ekid == j_ekid) || (i_ekid == j_akid) || (i_akid == j_ekid) || (i_akid == j_akid) || (j_ekid == j_akid))
+            {
+                status = CRYPTO_LIB_ERR_KEY_VALIDATION;
+#ifdef DEBUG
+                printf(KRED "SA Key Validation FAILURE!\n");
+                printf("Key Duplication SA: %d, EKID: %d, AKID: %d\n\tSA: %d, EKID: %d, AKID: %d\n", i, i_ekid, i_akid, j, j_ekid, j_akid);
+                printf("\n"RESET);
+#endif
+                break;
+            }
+        }
+    }
+    return status;
+}
 
 /**
  * @brief Function; sa_config
@@ -561,6 +606,9 @@ int32_t sa_config(void)
     if(use_internal)
     {
         sa_populate();
+#ifdef KEY_VALIDATION
+        status = key_validation();
+#endif
     }
 
     return status;
@@ -627,6 +675,9 @@ int32_t sa_init(void)
         }
 
         sa_populate();
+#ifdef KEY_VALIDATION
+        status = key_validation();
+#endif
     }    
     return status;
 }

--- a/support/scripts/build_internal.sh
+++ b/support/scripts/build_internal.sh
@@ -9,4 +9,4 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/env.sh
 
-cmake $BASE_DIR -DCODECOV=1 -DDEBUG=1 -DMC_INTERNAL=1 -DTEST=1 -DTEST_ENC=1 -DSA_FILE=1 && make && make test
+cmake $BASE_DIR -DCODECOV=1 -DDEBUG=1 -DMC_INTERNAL=1 -DTEST=1 -DTEST_ENC=1 -DSA_FILE=1 -DKEY_VALIDATION=0 && make && make test


### PR DESCRIPTION
Handles the internal side for now.

Additional Queries will be needed for MariaDB.  (Should hopefully be simple to implement on KMC side once we have automated containers for testing.

Added -DKEY_VALIDATION flags for ease of use later.

These changes will require us to tackle the SA modifications sooner than later, and then rework unit tests.

@jlucas9:
Should we create a separate issue for MDB/KMC additions, or leave this issue open for now?