### PR TITLE
217 mc how to handle where file is written

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ project(crypto C)
 set(SA_CUSTOM_PATH_DEFAULT "../../sa/custom")
 set(KEY_CUSTOM_PATH_DEFAULT "../../key/custom")
 set(MC_CUSTOM_PATH_DEFAULT "../../mc/custom")
-set(MC_LOG_PATH_DEFAULT "../../../log.txt")
+set(MC_LOG_PATH_DEFAULT "log.txt")
 set(CRYPTO_CUSTOM_PATH_DEFAULT "../../crypto/custom")
 
 
@@ -116,10 +116,11 @@ if(DEBUG)
     add_compile_options(-ggdb)
 endif()
 
-if(NOT DEFINED MC_LOG_CUSTOM_PATH)
-    add_definitions(-DMC_LOG_PATH=${MC_LOG_PATH_DEFAULT})
+if(DEFINED MC_LOG_CUSTOM_PATH)
+    message(STATUS "MC_LOG_CUSTOM_PATH set to: ${MC_LOG_CUSTOM_PATH}")
+    add_compile_definitions(MC_LOG_PATH="${MC_LOG_CUSTOM_PATH}")
 else()
-    add_definitions(-DMC_LOG_PATH=${MC_LOG_CUSTOM_PATH})
+    add_compile_definitions(MC_LOG_PATH="${MC_LOG_PATH_DEFAULT}")
 endif()
 
 IF(KMC_MDB_RH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ project(crypto C)
 set(SA_CUSTOM_PATH_DEFAULT "../../sa/custom")
 set(KEY_CUSTOM_PATH_DEFAULT "../../key/custom")
 set(MC_CUSTOM_PATH_DEFAULT "../../mc/custom")
+set(MC_LOG_PATH_DEFAULT "../../../log.txt")
 set(CRYPTO_CUSTOM_PATH_DEFAULT "../../crypto/custom")
 
 
@@ -113,6 +114,12 @@ endif()
 if(DEBUG)
     add_definitions(-DDEBUG -DOCF_DEBUG -DFECF_DEBUG -DSA_DEBUG -DPDU_DEBUG -DCCSDS_DEBUG -DTC_DEBUG -DMAC_DEBUG -DTM_DEBUG -DAOS_DEBUG)
     add_compile_options(-ggdb)
+endif()
+
+if(NOT DEFINED MC_LOG_CUSTOM_PATH)
+    add_definitions(-DMC_LOG_PATH=${MC_LOG_PATH_DEFAULT})
+else()
+    add_definitions(-DMC_LOG_PATH=${MC_LOG_CUSTOM_PATH})
 endif()
 
 IF(KMC_MDB_RH)

--- a/src/mc/internal/mc_interface_internal.template.c
+++ b/src/mc/internal/mc_interface_internal.template.c
@@ -57,7 +57,7 @@ static int32_t mc_initialize(void)
     if (mc_file_ptr == NULL)
     {
         status = CRYPTO_LIB_ERR_MC_INIT;
-        printf(KRED "ERROR: Monitoring andcontrol initialization - internal failed\n" RESET);
+        printf(KRED "ERROR: Monitoring and control initialization - internal failed\n" RESET);
     }
     
     return status;

--- a/src/mc/internal/mc_interface_internal.template.c
+++ b/src/mc/internal/mc_interface_internal.template.c
@@ -53,7 +53,7 @@ static int32_t mc_initialize(void)
     int32_t status = CRYPTO_LIB_SUCCESS;
     
     /* Open log */
-    mc_file_ptr = fopen("log.txt", "a");
+    mc_file_ptr = fopen(MC_LOG_PATH, "a");
     if (mc_file_ptr == NULL)
     {
         status = CRYPTO_LIB_ERR_MC_INIT;

--- a/support/scripts/build_internal.sh
+++ b/support/scripts/build_internal.sh
@@ -9,4 +9,6 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/env.sh
 
+rm $BASE_DIR/CMakeCache.txt
+
 cmake $BASE_DIR -DCODECOV=1 -DDEBUG=1 -DMC_INTERNAL=1 -DTEST=1 -DTEST_ENC=1 -DSA_FILE=1 && make && make test

--- a/support/scripts/build_kmc.sh
+++ b/support/scripts/build_kmc.sh
@@ -9,4 +9,6 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/env.sh
 
+rm $BASE_DIR/CMakeCache.txt
+
 cmake $BASE_DIR -DCODECOV=1 -DDEBUG=1 -DCRYPTO_KMC=1 -DKEY_KMC=1 -DMC_DISABLED=1 -DSA_MARIADB=1 -DTEST=1 -DTEST_ENC=1 -DKMC_CFFI_EXCLUDE=1 -DSA_FILE=1 && make && make test

--- a/support/scripts/build_minimal.sh
+++ b/support/scripts/build_minimal.sh
@@ -9,4 +9,6 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/env.sh
 
+rm $BASE_DIR/CMakeCache.txt
+
 cmake $BASE_DIR && make && make test

--- a/support/scripts/build_rhel.sh
+++ b/support/scripts/build_rhel.sh
@@ -9,4 +9,6 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/env.sh
 
+rm $BASE_DIR/CMakeCache.txt
+
 cmake $BASE_DIR -DCODECOV=1 -DDEBUG=1 -DMC_INTERNAL=1 -DTEST=1 -DTEST_ENC=1 -DSA_FILE=1 && make && make test

--- a/support/scripts/build_support.sh
+++ b/support/scripts/build_support.sh
@@ -9,4 +9,6 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/env.sh
 
+rm $BASE_DIR/CMakeCache.txt
+
 cmake $BASE_DIR -DCODECOV=1 -DDEBUG=1 -DSUPPORT=1 -DTEST=1 -DTEST_ENC=1 && make && make test

--- a/support/scripts/build_wolf.sh
+++ b/support/scripts/build_wolf.sh
@@ -9,4 +9,6 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source $SCRIPT_DIR/env.sh
 
+rm $BASE_DIR/CMakeCache.txt
+
 cmake $BASE_DIR -DCODECOV=1 -DDEBUG=1 -DCRYPTO_LIBGCRYPT=0 -DCRYPTO_WOLFSSL=1 -DTEST=1 -DTEST_ENC=1 -DSA_FILE=1 && make && make test


### PR DESCRIPTION
Allows you to specify the log file name or path via `-DMC_LOG_CUSTOM_PATH="filename.txt"` flag.