### PR TITLE
Packaging improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,9 @@ IF(KMC_MDB_DB)
 ENDIF(KMC_MDB_DB)
 
 if(SYSTEM_INSTALL)
-    set(CMAKE_INSTALL_PREFIX /usr/local)
+    # The library will be installed to /usr/local unless overridden with
+    # -DCMAKE_INSTALL_PREFIX=/some/path
+    # See https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html
 elseif(NOT DEFINED CFE_SYSTEM_PSPNAME)
     # Not cFE / cFS
     set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -158,6 +158,10 @@ endif()
 
 file(GLOB CRYPTO_INCLUDES ../include/*.h)
 set_target_properties(crypto PROPERTIES PUBLIC_HEADER "${CRYPTO_INCLUDES}")
+# This causes the library to be installed as libcryptolib.so while still being
+# referred to as crypto from CMake. Without this, the library filename would be
+# libcrypto.so which would conflict with openssl
+set_target_properties(crypto PROPERTIES OUTPUT_NAME "cryptolib")
 
 add_custom_command(TARGET crypto POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:crypto> ${PROJECT_BINARY_DIR}/lib/libcrypto.so


### PR DESCRIPTION
1. It is now possible to install the library to an arbitrary prefix by setting CMAKE_INSTALL_PREFIX and SYSTEM_INSTALL
2. The filename of the library no longer conflicts with openssl when installed. This should not have an effect when using the library as a git submodule.

Closes #271