### PR TITLE
JPL KMC SDLS integrated build Issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,8 @@ if(SYSTEM_INSTALL)
     # The library will be installed to /usr/local unless overridden with
     # -DCMAKE_INSTALL_PREFIX=/some/path
     # See https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html
+elseif(CRYPTO_SUBMODULE_INSTALL)
+    set(CMAKE_INSTALL_PREFIX ${CRYPTO_SUBMODULE_INSTALL})
 elseif(NOT DEFINED CFE_SYSTEM_PSPNAME)
     # Not cFE / cFS
     set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -179,8 +179,8 @@ else()
 endif()
 
 if(SA_MARIADB)
-    file(GLOB MYSQL_SCRIPTS sa/sa_mariadb_sql/*.sql)
-    file(GLOB MYSQL_TEST_SCRIPTS sa/test_sa_mariadb_sql/*.sql)
+    file(GLOB MYSQL_SCRIPTS sa/sadb_mariadb_sql/*.sql)
+    file(GLOB MYSQL_TEST_SCRIPTS sa/test_sadb_mariadb_sql/*.sql)
     install(FILES ${MYSQL_SCRIPTS}
             DESTINATION ${CMAKE_INSTALL_PREFIX}/etc/sa_mariadb_sql)
     install(FILES ${MYSQL_TEST_SCRIPTS}


### PR DESCRIPTION
- Allow build artifacts to be placed in the install directory at the AMMOS-Cryptolib level as it used to work before
- Fix a minor directory name typo