### PR TITLE
[nasa/cryptolib#379] Updated dockerfile and image tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     # Container Setup
     runs-on: ubuntu-latest
     container:
-        image: ivvitc/cryptolib:20240814
+        image: ivvitc/cryptolib:20241220
     steps:
     - uses: actions/checkout@v4
     - name: Update
@@ -51,7 +51,7 @@ jobs:
     # Container Setup
     runs-on: ubuntu-latest
     container:
-        image: ivvitc/cryptolib:20240814
+        image: ivvitc/cryptolib:20241220
     steps:
     - uses: actions/checkout@v4
     - name: Update
@@ -151,7 +151,7 @@ jobs:
     # Container Setup
     runs-on: ubuntu-latest
     container:
-        image: ivvitc/cryptolib:20240814
+        image: ivvitc/cryptolib:20241220
     steps:
     - uses: actions/checkout@v4
     - name: Update
@@ -277,7 +277,7 @@ jobs:
     # Container Setup
     runs-on: ubuntu-latest
     container:
-        image: ivvitc/cryptolib:20240814
+        image: ivvitc/cryptolib:20241220
     steps:
     - uses: actions/checkout@v4
     - name: Update

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
     name: Analyze Build_Internal
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     container:
-        image: ivvitc/cryptolib:20240814
+        image: ivvitc/cryptolib:20241220
     permissions:
       # required for all workflows
       security-events: write
@@ -74,7 +74,7 @@ jobs:
       name: Analyze Build_Minimal
       runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
       container:
-        image: ivvitc/cryptolib:20240814
+        image: ivvitc/cryptolib:20241220
       permissions:
         # required for all workflows
         security-events: write
@@ -126,7 +126,7 @@ jobs:
       name: Analyze Build_Wolf
       runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
       container:
-        image: ivvitc/cryptolib:20240814
+        image: ivvitc/cryptolib:20241220
       permissions:
         # required for all workflows
         security-events: write
@@ -207,7 +207,7 @@ jobs:
       name: Analyze Build_RHEL
       runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
       container:
-        image: ivvitc/cryptolib:20240814
+        image: ivvitc/cryptolib:20241220
       permissions:
         # required for all workflows
         security-events: write
@@ -259,7 +259,7 @@ jobs:
     name: Analyze Build_EP
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     container:
-        image: ivvitc/cryptolib:20240814
+        image: ivvitc/cryptolib:20241220
     permissions:
       # required for all workflows
       security-events: write

--- a/support/Dockerfile
+++ b/support/Dockerfile
@@ -57,7 +57,8 @@ RUN curl \
     && tar -xjf /tmp/libgcrypt-${GCRYPT_VERSION}.tar.bz2 -C /tmp/ \
     && cd /tmp/libgcrypt-${GCRYPT_VERSION} \
     && ./configure \
-    && make install
+    && make install \
+    && ldconfig
 
 FROM cl1 AS cl2
 ARG WOLFSSL_VERSION=5.6.0-stable

--- a/support/scripts/env.sh
+++ b/support/scripts/env.sh
@@ -10,4 +10,4 @@ export BASE_DIR=$(cd `dirname $SCRIPT_DIR`/.. && pwd)
 
 DFLAGS="docker run --rm -it -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -u $(id -u $(stat -c '%U' $SCRIPT_DIR/env.sh)):$(getent group $(stat -c '%G' $SCRIPT_DIR/env.sh) | cut -d: -f3)"
 
-DBOX="ivvitc/cryptolib:20240814"
+DBOX="ivvitc/cryptolib:20241220"


### PR DESCRIPTION
Initially used the wrong dating convention, so now both the `122024` and `20241220` tags exist. Turns out this was already part of the image, but we didn't update the tags in the build CI.

closes nasa/cryptolib#379