### PR TITLE
feat: add fuzzing harness and infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__
 *.dat
 *.so
 build/
+build-*/
 venv
 vgcore*
 core.*
@@ -23,6 +24,8 @@ DartConfiguration.tcl
 sa_save_file.bin
 bin/*
 CMakeFiles/*
+fuzz/corpus/
+fuzz/output/
 src/cmake_install.cmake
 src/CTestTestfile.cmake
 src/CMakeFiles/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ option(CRYPTO_WOLFSSL "Cryptography Module - WolfSSL" OFF)
 option(CRYPTO_CUSTOM "Cryptography Module - CUSTOM" OFF)
 option(CRYPTO_CUSTOM_PATH "Cryptography Module - CUSTOM PATH" OFF)
 option(DEBUG "Debug" OFF)
+option(ENABLE_FUZZING "Enable fuzz testing" OFF)
 option(KEY_CUSTOM "Key Module - Custom" OFF)
 option(KEY_CUSTOM_PATH "Custom Key Path" OFF)
 option(KEY_INTERNAL "Key Module - Internal" OFF)
@@ -191,7 +192,13 @@ endif()
 #
 # Project Specifics
 #
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -g -O0")
+if(ENABLE_FUZZING) 
+    # More permissive flags for fuzzing (afl compiler fails with -Werror for self-assign warnings)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-self-assign -g -O0")
+else()
+    # Stricter flags for normal builds (treat warnings as errors)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -g -O0")
+endif()
 
 include_directories(include)
 add_subdirectory(src)
@@ -202,4 +209,8 @@ endif()
 
 if(TEST)
     add_subdirectory(test)
+endif()
+
+if(ENABLE_FUZZING)
+    add_subdirectory(fuzz)
 endif()

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Include necessary directories
+include_directories(include)
+include_directories(../include)
+include_directories(../test/include)
+
+# Create shared utils library from test code
+add_library(shared_utils STATIC ../test/core/shared_util.c)
+
+# Build the fuzzing harness
+add_executable(fuzz_harness src/fuzz_harness.c)
+target_link_libraries(fuzz_harness LINK_PUBLIC shared_utils crypto pthread)
+
+# Add fuzzing-specific compiler flags
+target_compile_options(fuzz_harness PRIVATE -fsanitize=fuzzer -g)
+target_link_options(fuzz_harness PRIVATE -fsanitize=fuzzer)
+
+# Copy the executable to bin directory
+add_custom_command(TARGET fuzz_harness POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:fuzz_harness> ${PROJECT_BINARY_DIR}/bin/fuzz_harness
+        COMMAND ${CMAKE_COMMAND} -E remove $<TARGET_FILE:fuzz_harness>
+        COMMENT "Created ${PROJECT_BINARY_DIR}/bin/fuzz_harness"
+        )

--- a/fuzz/generate_corpus.py
+++ b/fuzz/generate_corpus.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+
+import os
+import random
+import struct
+import argparse
+from pathlib import Path
+
+
+def ensure_dir(directory):
+    """Create directory if it doesn't exist"""
+    Path(directory).mkdir(parents=True, exist_ok=True)
+
+
+def generate_random_bytes(min_size, max_size):
+    """Generate random bytes of size between min_size and max_size"""
+    size = random.randint(min_size, max_size)
+    return bytes(random.randint(0, 255) for _ in range(size))
+
+
+def generate_tc_frame(random_content=True):
+    """Generate a TC frame with valid-looking header"""
+    if random_content:
+        frame_size = random.randint(10, 200)
+        frame = bytearray(generate_random_bytes(frame_size, frame_size))
+    else:
+        frame_size = 10
+        frame = bytearray(frame_size)
+
+    # Set basic TC frame header fields
+    frame[0] = 0x20  # Version 1, Type TC
+    frame[1] = 0x03  # SCID
+    frame[2] = 0x00  # VCID
+    frame[3] = (frame_size - 5) & 0xFF  # Frame length
+
+    return frame
+
+
+def generate_tm_frame(random_content=True):
+    """Generate a TM frame with valid-looking header"""
+    if random_content:
+        frame_size = random.randint(12, 200)
+        frame = bytearray(generate_random_bytes(frame_size, frame_size))
+    else:
+        frame_size = 12
+        frame = bytearray(frame_size)
+
+    # Set basic TM frame header fields
+    frame[0] = 0x08  # Version 1, TM
+    frame[1] = 0x03  # SCID
+    frame[2] = 0x00  # VCID
+
+    return frame
+
+
+def generate_aos_frame(random_content=True):
+    """Generate an AOS frame with valid-looking header"""
+    if random_content:
+        frame_size = random.randint(14, 200)
+        frame = bytearray(generate_random_bytes(frame_size, frame_size))
+    else:
+        frame_size = 14
+        frame = bytearray(frame_size)
+
+    # Set basic AOS frame header fields
+    frame[0] = 0x10  # Version 1, AOS
+    frame[1] = 0x03  # SCID
+    frame[2] = 0x00  # VCID
+
+    return frame
+
+
+def generate_corpus(output_dir, num_samples_per_selector=5):
+    """Generate corpus files for each selector value"""
+    ensure_dir(output_dir)
+
+    # Generate samples for each selector (0-6)
+    for selector in range(7):
+        for i in range(num_samples_per_selector):
+            # File naming: selector_type_variant.bin
+            if selector in [0, 1]:  # TC frame operations
+                frame = generate_tc_frame(random_content=(i != 0))
+                file_name = f"{selector:02d}_tc_{i:02d}.bin"
+            elif selector in [2, 5]:  # TM frame operations
+                frame = generate_tm_frame(random_content=(i != 0))
+                file_name = f"{selector:02d}_tm_{i:02d}.bin"
+            elif selector in [3, 4]:  # AOS frame operations
+                frame = generate_aos_frame(random_content=(i != 0))
+                file_name = f"{selector:02d}_aos_{i:02d}.bin"
+            else:  # selector == 6, TC frame for FECF check
+                frame = generate_tc_frame(random_content=(i != 0))
+                file_name = f"{selector:02d}_tc_fecf_{i:02d}.bin"
+
+            # Add the selector byte at the beginning
+            output = bytearray([selector]) + frame
+
+            # Write to file
+            with open(os.path.join(output_dir, file_name), "wb") as f:
+                f.write(output)
+
+    # Generate some edge cases
+    edge_cases = [
+        # Minimal valid input (just selector)
+        (0, bytearray([0])),
+        (1, bytearray([1])),
+        (2, bytearray([2])),
+        (3, bytearray([3])),
+        (4, bytearray([4])),
+        (5, bytearray([5])),
+        (6, bytearray([6])),
+
+        # Very large inputs
+        (0, bytearray([0]) + generate_random_bytes(2000, 2000)),
+        (3, bytearray([3]) + generate_random_bytes(2000, 2000)),
+
+        # Interesting byte patterns
+        (0, bytearray([0]) + bytes([0xFF] * 50)),
+        (1, bytearray([1]) + bytes([0x00] * 50)),
+        (2, bytearray([2]) + bytes([i % 256 for i in range(100)])),
+        (5, bytearray([5]) + bytes([0xAA, 0x55] * 25))  # Alternating bits
+    ]
+
+    for idx, (selector, data) in enumerate(edge_cases):
+        file_name = f"edge_{idx:02d}_sel{selector}.bin"
+        with open(os.path.join(output_dir, file_name), "wb") as f:
+            f.write(data)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate corpus for CryptoLib fuzzer')
+    parser.add_argument('--output', '-o', default='corpus',
+                        help='Output directory for corpus files')
+    parser.add_argument('--samples', '-n', type=int, default=5,
+                        help='Number of samples per selector')
+    args = parser.parse_args()
+
+    print(f"Generating corpus in directory: {args.output}")
+    generate_corpus(args.output, args.samples)
+    print(f"Generated {7 * args.samples + 11} corpus files")
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/scripts/build-fuzz.sh
+++ b/fuzz/scripts/build-fuzz.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+# === Configuration Options ===
+# Set to 1 to enable aggressive optimizations (requires CPU with AVX2/FMA support)
+# Set to 0 for more compatible builds
+ENABLE_OPTIMIZATIONS=1
+
+# Navigate to project root directory
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$PROJECT_ROOT"
+echo "🏠 Working from project root: $PROJECT_ROOT"
+
+
+# === Check for AFL++ and select best compiler ===
+echo "🔍 Checking for AFL++ compilers..."
+
+if command -v afl-clang-lto &> /dev/null; then
+    echo "✅ Found afl-clang-lto (recommended LTO mode)"
+    CC=afl-clang-lto
+    CXX=afl-clang-lto++
+elif command -v afl-clang-fast &> /dev/null; then
+    echo "✅ Found afl-clang-fast (LLVM mode)"
+    CC=afl-clang-fast
+    CXX=afl-clang-fast++
+elif command -v afl-gcc-fast &> /dev/null; then
+    echo "✅ Found afl-gcc-fast (GCC plugin mode)"
+    CC=afl-gcc-fast
+    CXX=afl-g++-fast
+elif command -v afl-gcc &> /dev/null; then
+    echo "✅ Found afl-gcc (basic AFL instrumentation)"
+    CC=afl-gcc
+    CXX=afl-g++
+else
+    echo "❌ ERROR: No AFL++ compilers found. Please install AFL++ first:"
+    echo "    git clone https://github.com/AFLplusplus/AFLplusplus"
+    echo "    cd AFLplusplus && make && sudo make install"
+    echo "See: https://github.com/AFLplusplus/AFLplusplus/blob/stable/docs/INSTALL.md"
+    exit 1
+fi
+
+# Export the selected compiler
+export CC=$CC
+export CXX=$CXX
+
+# Number of CPU cores for parallel compilation
+CORES=$(nproc)
+
+# Set optimization flags based on configuration
+if [ $ENABLE_OPTIMIZATIONS -eq 1 ]; then
+    echo "⚠️  Using aggressive optimizations (requires CPU with AVX2/FMA support)"
+    OPT_FLAGS="-O3 -march=native -mtune=native -flto -funroll-loops -ffast-math -mavx2 -mfma"
+else
+    echo "ℹ️  Using standard optimization level (compatible with most CPUs)"
+    OPT_FLAGS="-O2"
+fi
+
+# === Compile without ASan ===
+echo "🔨 Compiling CryptoLib without ASan..."
+rm -rf build
+mkdir build && cd build
+cmake .. -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX \
+  -DCMAKE_C_FLAGS="$OPT_FLAGS" \
+  -DCMAKE_CXX_FLAGS="$OPT_FLAGS" \
+  -DCMAKE_EXE_LINKER_FLAGS="-flto" \
+  -DCRYPTO_LIBGCRYPT=ON \
+  -DENABLE_FUZZING=ON \
+  -DDEBUG=ON \
+  -DKEY_INTERNAL=ON \
+  -DMC_INTERNAL=ON \
+  -DSA_INTERNAL=ON
+make -j$CORES
+cd ..
+
+# === Compile with ASan ===
+echo "🔨 Compiling CryptoLib with ASan..."
+rm -rf build-asan
+mkdir build-asan && cd build-asan
+cmake .. -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX \
+  -DCMAKE_C_FLAGS="-fsanitize=address $OPT_FLAGS" \
+  -DCMAKE_CXX_FLAGS="-fsanitize=address $OPT_FLAGS" \
+  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address -flto" \
+  -DCRYPTO_LIBGCRYPT=ON \
+  -DENABLE_FUZZING=ON \
+  -DDEBUG=ON \
+  -DKEY_INTERNAL=ON \
+  -DMC_INTERNAL=ON \
+  -DSA_INTERNAL=ON
+make -j$CORES
+cd ..
+
+# === Compile with CmpLog ===
+echo "🔨 Compiling CryptoLib with CmpLog instrumentation..."
+rm -rf build-cmplog
+mkdir build-cmplog && cd build-cmplog
+export AFL_LLVM_CMPLOG=1 # Enable CmpLog instrumentation
+cmake .. -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX \
+  -DCMAKE_C_FLAGS="$OPT_FLAGS" \
+  -DCMAKE_CXX_FLAGS="$OPT_FLAGS" \
+  -DCRYPTO_LIBGCRYPT=ON \
+  -DENABLE_FUZZING=ON \
+  -DDEBUG=ON \
+  -DKEY_INTERNAL=ON \
+  -DMC_INTERNAL=ON \
+  -DSA_INTERNAL=ON
+make -j$CORES
+unset AFL_LLVM_CMPLOG # Unset to avoid affecting other builds
+cd ..
+
+# === Compile with CompCov (laf-intel) ===
+echo "🔨 Compiling CryptoLib with CompCov (laf-intel) instrumentation..."
+rm -rf build-compcov
+mkdir build-compcov && cd build-compcov
+export AFL_LLVM_LAF_ALL=1 # Enable CompCov instrumentation
+cmake .. -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX \
+  -DCMAKE_C_FLAGS="$OPT_FLAGS" \
+  -DCMAKE_CXX_FLAGS="$OPT_FLAGS" \
+  -DCRYPTO_LIBGCRYPT=ON \
+  -DENABLE_FUZZING=ON \
+  -DDEBUG=ON \
+  -DKEY_INTERNAL=ON \
+  -DMC_INTERNAL=ON \
+  -DSA_INTERNAL=ON
+make -j$CORES
+unset AFL_LLVM_LAF_ALL # Unset to avoid affecting other builds
+cd ..
+
+# === Final Status ===
+echo "✅ Build complete!"
+echo "📂 Non-ASan build:     'build/'"
+echo "📂 ASan build:         'build-asan/'"
+echo "📂 CmpLog build:       'build-cmplog/'"
+echo "📂 CompCov (laf-intel) build: 'build-compcov/'"
+echo ""
+echo "To run fuzzing with AFL++:"
+echo "$(dirname "$0")/run-fuzz-multithreaded.sh"
+echo ""
+echo "⚠️  AFL++ SYSTEM CONFIGURATION REMINDERS ⚠️"
+echo "For optimal fuzzing performance, consider running these commands:"
+echo ""
+echo "1️⃣  Disable CPU frequency scaling:"
+echo "   echo performance | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor"
+echo ""
+echo "2️⃣  Configure core pattern for crash analysis:"
+echo "   echo core | sudo tee /proc/sys/kernel/core_pattern"
+echo ""
+echo "📋 TROUBLESHOOTING FUZZING SESSIONS 📋"
+echo "If the fuzzer does not start or you encounter issues:"
+echo ""
+echo "1. List all screen sessions:"
+echo "   screen -ls"
+echo ""
+echo "2. Reattach to a specific session to see errors:"
+echo "   screen -r session_name"
+echo ""
+echo "3. To detach from a screen session: Press Ctrl+A, then D"

--- a/fuzz/scripts/run-fuzz-multithreaded.sh
+++ b/fuzz/scripts/run-fuzz-multithreaded.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# === CONFIGURABLE VARIABLES ===
+# MEM_LIMIT=128                                       # Memory limit for AFL++
+SEEDS_DIR="../corpus"                                 # Directory containing grammar mutator seed files
+OUT_DIR="../output"                                   # AFL++ output directory
+TARGET_BINARY="../../build/bin/fuzz_harness"          # Default build target
+ASAN_BINARY="../../build-asan/bin/fuzz_harness"       # ASan build target
+CMPLOG_BINARY="../../build-cmplog/bin/fuzz_harness"   # CMPLOG build target
+COMPCOV_BINARY="../../build-compcov/bin/fuzz_harness" # CompCov (laf-intel) build target
+NUM_CORES=$(($(nproc) - 2))                           # Use all cores except 2 for OS
+
+# === CHECK IF AFL++ AND SCREEN ARE INSTALLED ===
+if ! command -v afl-fuzz &>/dev/null; then
+  echo "❌ AFL++ is not installed. Install it before running this script."
+  exit 1
+fi
+
+if ! command -v screen &>/dev/null; then
+  echo "❌ 'screen' is not installed. Install it with 'sudo apt-get install screen' or 'sudo dnf install screen'."
+  exit 1
+fi
+
+# === EXPORT GLOBAL ENVIRONMENT VARIABLES ===
+export AFL_TESTCACHE_SIZE=100     # Enable caching of test cases
+export AFL_IMPORT_FIRST=1         # Prioritize loading test cases from other fuzzers
+export AFL_IGNORE_SEED_PROBLEMS=1 # Ignore problematic seeds
+
+# === PRINT CONFIGURATION ===
+echo "🚀 Starting AFL++ Multi-core Fuzzing in 'screen' sessions"
+echo "📂 Output Directory: $OUT_DIR"
+echo "💾 Memory Limit: $MEM_LIMIT MB"
+echo "🖥️  Using $NUM_CORES cores for fuzzing."
+
+# === START AFL++ FUZZING INSTANCES IN SCREEN SESSIONS ===
+
+# Master Fuzzer: Using explore strategy
+screen -dmS afl_main bash -c "AFL_FINAL_SYNC=1 AFL_AUTORESUME=1 afl-fuzz -M main0 -i '$SEEDS_DIR' -o '$OUT_DIR' -p explore -- '$TARGET_BINARY' @@; exec bash"
+
+# Secondary Fuzzers Configuration Counters
+ASAN_COUNT=0
+CMPLOG_COUNT=0
+COMPCOV_COUNT=0
+MOPT_COUNT=0
+OLD_QUEUE_COUNT=0
+DISABLE_TRIM_COUNT=0
+
+# Recommended Limits
+CMPLOG_MAX=2
+COMPCOV_MAX=3
+MOPT_MAX=$(($NUM_CORES / 10))        # 10% for MOpt
+OLD_QUEUE_MAX=$(($NUM_CORES / 10))   # 10% for old queue
+DISABLE_TRIM_MIN=$(($NUM_CORES / 2)) # At least 50% for AFL_DISABLE_TRIM
+
+# Power Schedules
+POWER_SCHEDULES=("fast" "explore" "coe" "lin" "quad" "exploit" "rare")
+
+# Start Secondary Fuzzers
+for i in $(seq 1 $NUM_CORES); do
+  FUZZER_NAME="main$i"
+  SCREEN_SESSION="afl_$FUZZER_NAME"
+  CMD="AFL_AUTORESUME=1 afl-fuzz -S '$FUZZER_NAME' -i '$SEEDS_DIR' -o '$OUT_DIR'"
+
+  # Apply configurations based on counters and recommendations
+  if [ $ASAN_COUNT -lt 1 ]; then
+    CMD="AFL_USE_ASAN=1 $CMD -p fast -- '$ASAN_BINARY' @@"
+    ASAN_COUNT=$((ASAN_COUNT + 1))
+  elif [ $CMPLOG_COUNT -lt $CMPLOG_MAX ]; then
+    if [ $CMPLOG_COUNT -eq 0 ]; then
+      CMD="$CMD -p coe -l 2 -- '$CMPLOG_BINARY' @@"
+    else
+      CMD="$CMD -p lin -l 2AT -- '$CMPLOG_BINARY' @@"
+    fi
+    CMPLOG_COUNT=$((CMPLOG_COUNT + 1))
+  elif [ $COMPCOV_COUNT -lt $COMPCOV_MAX ]; then
+    CMD="$CMD -p explore -- '$COMPCOV_BINARY' @@"
+    COMPCOV_COUNT=$((COMPCOV_COUNT + 1))
+  elif [ $MOPT_COUNT -lt $MOPT_MAX ]; then
+    CMD="$CMD -p quad -L 0 -- '$TARGET_BINARY' @@"
+    MOPT_COUNT=$((MOPT_COUNT + 1))
+  elif [ $OLD_QUEUE_COUNT -lt $OLD_QUEUE_MAX ]; then
+    CMD="$CMD -p rare -Z -- '$TARGET_BINARY' @@"
+    OLD_QUEUE_COUNT=$((OLD_QUEUE_COUNT + 1))
+  elif [ $DISABLE_TRIM_COUNT -lt $DISABLE_TRIM_MIN ]; then
+    CMD="AFL_DISABLE_TRIM=1 $CMD -p exploit -- '$TARGET_BINARY' @@"
+    DISABLE_TRIM_COUNT=$((DISABLE_TRIM_COUNT + 1))
+  else
+    # Default configuration if all quotas are met
+    RANDOM_POWER_SCHEDULE=${POWER_SCHEDULES[$((RANDOM % ${#POWER_SCHEDULES[@]}))]}
+    CMD="$CMD -p $RANDOM_POWER_SCHEDULE -- '$TARGET_BINARY' @@"
+  fi
+
+  # Launch in screen session
+  screen -dmS "$SCREEN_SESSION" bash -c "$CMD; exec bash"
+  echo "🖥️  Started fuzzer in screen session '$SCREEN_SESSION'"
+done
+
+# === PERIODIC AFL++ STATUS UPDATES ===
+sleep 10
+echo "📊 Starting AFL++ status updates every 10 seconds (Press Ctrl+C to stop monitoring)..."
+while true; do
+  clear
+  echo "📈 AFL++ Fuzzing Status (Updated every 10 seconds)"
+  afl-whatsup -s "$OUT_DIR"
+  sleep 10
+done

--- a/fuzz/src/fuzz_harness.c
+++ b/fuzz/src/fuzz_harness.c
@@ -1,0 +1,277 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <signal.h>
+#include <setjmp.h>
+#include "crypto.h"
+
+// Global variables
+static jmp_buf crash_jmp_buf;
+
+#define MAX_FRAME_SIZE 2048
+static uint8_t tc_frame_buffer[MAX_FRAME_SIZE];
+static uint8_t tm_frame_buffer[MAX_FRAME_SIZE];
+static uint8_t aos_frame_buffer[MAX_FRAME_SIZE];
+
+// Signal handler for crashes
+static void crash_handler(int sig)
+{
+    signal(sig, SIG_DFL);
+    longjmp(crash_jmp_buf, 1);
+}
+
+static int32_t init_cryptolib_for_fuzzing(void)
+{
+    int32_t status;
+
+    // Configure CryptoLib with settings for all protocols
+    Crypto_Config_CryptoLib(KEY_TYPE_INTERNAL,                  // Use internal key management
+                            MC_TYPE_INTERNAL,                   // Use internal message counting
+                            SA_TYPE_INMEMORY,                   // Use in-memory security associations
+                            CRYPTOGRAPHY_TYPE_LIBGCRYPT,        // Use libgcrypt for crypto operations
+                            IV_INTERNAL,                        // Use internal IV generation
+                            CRYPTO_TC_CREATE_FECF_TRUE,         // Create FECF for TC frames
+                            TC_PROCESS_SDLS_PDUS_TRUE,          // Process SDLS PDUs for TC frames
+                            TC_HAS_PUS_HDR,                     // TC frames have PUS headers
+                            TC_IGNORE_SA_STATE_FALSE,           // Don't ignore SA state
+                            TC_IGNORE_ANTI_REPLAY_FALSE,        // Don't ignore anti-replay
+                            TC_UNIQUE_SA_PER_MAP_ID_FALSE,      // Don't use unique SAs per MAP ID
+                            TC_CHECK_FECF_TRUE,                 // Check FECF for TC frames
+                            0x3F,                               // TC security flags
+                            SA_INCREMENT_NONTRANSMITTED_IV_TRUE // Increment non-transmitted IV
+    );
+
+    // Add parameters for TC, TM, and AOS protocols
+    GvcidManagedParameters_t TC_Parameters = {
+        0, 0x0003, 0, TC_HAS_FECF, AOS_FHEC_NA, AOS_IZ_NA, 0, TC_HAS_SEGMENT_HDRS, 1024, TC_OCF_NA, 1};
+    Crypto_Config_Add_Gvcid_Managed_Parameters(TC_Parameters);
+
+    GvcidManagedParameters_t TM_Parameters = {
+        0, 0x0003, 0, TM_HAS_FECF, AOS_FHEC_NA, AOS_IZ_NA, 0, TM_SEGMENT_HDRS_NA, 1786, TM_NO_OCF, 1};
+    Crypto_Config_Add_Gvcid_Managed_Parameters(TM_Parameters);
+
+    GvcidManagedParameters_t AOS_Parameters = {
+        1, 0x0003, 0, AOS_HAS_FECF, AOS_FHEC_NA, AOS_IZ_NA, 0, AOS_SEGMENT_HDRS_NA, 1786, AOS_NO_OCF, 1};
+    Crypto_Config_Add_Gvcid_Managed_Parameters(AOS_Parameters);
+
+    // Initialize the library
+    status = Crypto_Init();
+    return status;
+}
+
+static void reset_cryptolib(void)
+{
+    Crypto_Shutdown();
+    init_cryptolib_for_fuzzing();
+}
+
+// Modify create_tc_frame to use static buffer
+static uint8_t *create_tc_frame(const uint8_t *data, size_t size, size_t *out_size)
+{
+    const size_t MIN_TC_SIZE = 10;
+    size_t       frame_size  = (size < MIN_TC_SIZE) ? MIN_TC_SIZE : size;
+
+    if (frame_size > MAX_FRAME_SIZE)
+    {
+        frame_size = MAX_FRAME_SIZE;
+    }
+    *out_size = frame_size;
+
+    if (size < MIN_TC_SIZE)
+    {
+        memset(tc_frame_buffer, 0, MIN_TC_SIZE);
+        tc_frame_buffer[0] = 0x20; // Version 1, Type TC
+        tc_frame_buffer[1] = 0x03; // SCID
+        tc_frame_buffer[2] = 0x00; // VCID
+        tc_frame_buffer[3] = 0x02; // Frame length
+    }
+    else
+    {
+        memcpy(tc_frame_buffer, data, frame_size);
+    }
+    return tc_frame_buffer;
+}
+
+// Similarly modify create_tm_frame and create_aos_frame
+static uint8_t *create_tm_frame(const uint8_t *data, size_t size, size_t *out_size)
+{
+    const size_t MIN_TM_SIZE = 12;
+    size_t       frame_size  = (size < MIN_TM_SIZE) ? MIN_TM_SIZE : size;
+
+    if (frame_size > MAX_FRAME_SIZE)
+    {
+        frame_size = MAX_FRAME_SIZE;
+    }
+    *out_size = frame_size;
+
+    if (size < MIN_TM_SIZE)
+    {
+        memset(tm_frame_buffer, 0, MIN_TM_SIZE);
+        tm_frame_buffer[0] = 0x08; // Version 1, TM
+        tm_frame_buffer[1] = 0x03; // SCID
+        tm_frame_buffer[2] = 0x00; // VCID
+    }
+    else
+    {
+        memcpy(tm_frame_buffer, data, frame_size);
+    }
+    return tm_frame_buffer;
+}
+
+static uint8_t *create_aos_frame(const uint8_t *data, size_t size, size_t *out_size)
+{
+    const size_t MIN_AOS_SIZE = 14;
+    size_t       frame_size   = (size < MIN_AOS_SIZE) ? MIN_AOS_SIZE : size;
+
+    if (frame_size > MAX_FRAME_SIZE)
+    {
+        frame_size = MAX_FRAME_SIZE;
+    }
+    *out_size = frame_size;
+
+    if (size < MIN_AOS_SIZE)
+    {
+        memset(aos_frame_buffer, 0, MIN_AOS_SIZE);
+        aos_frame_buffer[0] = 0x10; // Version 1, AOS
+        aos_frame_buffer[1] = 0x03; // SCID
+        aos_frame_buffer[2] = 0x00; // VCID
+    }
+    else
+    {
+        memcpy(aos_frame_buffer, data, frame_size);
+    }
+    return aos_frame_buffer;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    // Set up crash handling
+    if (setjmp(crash_jmp_buf) != 0)
+    {
+        return 0; // Return if we caught a crash
+    }
+    signal(SIGSEGV, crash_handler);
+    signal(SIGABRT, crash_handler);
+    signal(SIGILL, crash_handler);
+    signal(SIGFPE, crash_handler);
+
+    // Initialize on first run
+    static int initialized = 0;
+    if (!initialized)
+    {
+        init_cryptolib_for_fuzzing();
+        initialized = 1;
+    }
+
+    // Need at least one byte for selector
+    if (size < 1)
+        return 0;
+
+    uint8_t        selector     = data[0];
+    const uint8_t *payload      = data + 1;
+    size_t         payload_size = size - 1;
+
+    // Select which API to fuzz (7 total functions)
+    switch (selector % 7)
+    {
+        case 0:
+        {
+            // Crypto_TC_ApplySecurity
+            size_t   frame_size = 0;
+            uint8_t *frame      = create_tc_frame(payload, payload_size, &frame_size);
+            if (frame)
+            {
+                uint8_t *out_frame = NULL;
+                uint16_t out_size  = 0;
+                Crypto_TC_ApplySecurity(frame, (uint16_t)frame_size, &out_frame, &out_size);
+                if (out_frame)
+                    free(out_frame);
+            }
+            break;
+        }
+        case 1:
+        {
+            // Crypto_TC_ProcessSecurity
+            size_t   frame_size = 0;
+            uint8_t *frame      = create_tc_frame(payload, payload_size, &frame_size);
+            if (frame)
+            {
+                int  len      = frame_size;
+                TC_t tc_frame = {0};
+                Crypto_TC_ProcessSecurity(frame, &len, &tc_frame);
+            }
+            break;
+        }
+        case 2:
+        {
+            // Crypto_TM_ApplySecurity
+            size_t   frame_size = 0;
+            uint8_t *frame      = create_tm_frame(payload, payload_size, &frame_size);
+            if (frame)
+            {
+                Crypto_TM_ApplySecurity(frame, (uint16_t)frame_size);
+            }
+            break;
+        }
+        case 3:
+        {
+            // Crypto_AOS_ApplySecurity
+            size_t   frame_size = 0;
+            uint8_t *frame      = create_aos_frame(payload, payload_size, &frame_size);
+            if (frame)
+            {
+                Crypto_AOS_ApplySecurity(frame, (uint16_t)frame_size);
+            }
+            break;
+        }
+        case 4:
+        {
+            // Crypto_AOS_ProcessSecurity
+            size_t   frame_size = 0;
+            uint8_t *frame      = create_aos_frame(payload, payload_size, &frame_size);
+            if (frame)
+            {
+                uint8_t *out_frame = NULL;
+                uint16_t out_size  = 0;
+                Crypto_AOS_ProcessSecurity(frame, (uint16_t)frame_size, &out_frame, &out_size);
+                if (out_frame)
+                    free(out_frame);
+            }
+            break;
+        }
+        case 5:
+        {
+            // Crypto_TM_ProcessSecurity
+            size_t   frame_size = 0;
+            uint8_t *frame      = create_tm_frame(payload, payload_size, &frame_size);
+            if (frame)
+            {
+                uint8_t *out_frame = NULL;
+                uint16_t out_size  = 0;
+                Crypto_TM_ProcessSecurity(frame, (uint16_t)frame_size, &out_frame, &out_size);
+                if (out_frame)
+                    free(out_frame);
+            }
+            break;
+        }
+
+        case 6:
+        {
+            // Crypto_Parse_Check_FECF
+            size_t   frame_size = 0;
+            uint8_t *frame      = create_tc_frame(payload, payload_size, &frame_size);
+            if (frame)
+            {
+                int  len      = frame_size;
+                TC_t tc_frame = {0};
+                Crypto_TC_Parse_Check_FECF(frame, &len, &tc_frame);
+            }
+            break;
+        }
+    }
+
+    reset_cryptolib();
+
+    return 0;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/nasa/CryptoLib/blob/main/doc/CryptoLib_Indv_CLA.pdf) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/cryptolib/pulls) for the same update/change?

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

---

## 🔍 What This PR Does

This PR introduces native **fuzz testing support** to CryptoLib. The implementation is designed to help uncover memory safety issues and logic bugs across core security-related APIs. This is in response to [Issue #369](https://github.com/nasa/CryptoLib/issues/369).

---

## 🧪 Included in This PR

- A **fuzzing harness** (`fuzz_harness.c`) based on `LLVMFuzzerTestOneInput`, targeting 7 critical API functions:
  - `Crypto_TC_ApplySecurity`
  - `Crypto_TC_ProcessSecurity`
  - `Crypto_TM_ApplySecurity`
  - `Crypto_TM_ProcessSecurity`
  - `Crypto_AOS_ApplySecurity`
  - `Crypto_AOS_ProcessSecurity`
  - `Crypto_TC_Parse_Check_FECF`

- **Persistent mode support** with a `reset_cryptolib()` to ensure state isolation per fuzz iteration.

- **Corpus generation script** (`generate_corpus.py`) to seed fuzzing campaigns with protocol-valid frames across TC, TM, and AOS.

- **Multithreaded fuzzing launcher** (`run-fuzz-multithreaded.sh`) using AFL++ best practices:
  - CMPLOG, ASAN, LAF-Intel (CompCov), MOpt, and custom power schedules
  - Parallelized with `screen` sessions
  - Periodic status reports using `afl-whatsup`

- **Build script** (`build-fuzz.sh`) compiling 4 fuzz-targeted instrumented builds:
  - Default, AddressSanitizer, CMPLOG, and CompCov
  - Optional performance-optimized builds with `-march=native`, AVX2/FMA, `-flto`, etc.

- **CMake integration** via `ENABLE_FUZZING` toggle.

---

## 🧪 How to Test These Changes

1. Install [AFL++](https://github.com/AFLplusplus/AFLplusplus).
2. Run the build script:
   ```bash
   cd fuzz/scripts
   ./build-fuzz.sh
   ```
3. Generate corpus:
   ```bash
   cd ../
   python generate_corpus.py
   ```
4. Launch multi-core fuzzing:
   ```bash
   ./scripts/run-fuzz-multithreaded.sh
   ```
5. Monitor progress with:
   ```bash
   screen -ls
   screen -r afl_main
   afl-whatsup -s output/
   ```

---

## 📌 Additional Notes

- The fuzzing corpus currently uses a basic randomized generator. There is **room for future enhancement** using protocol-aware or coverage-guided corpus generation techniques.

- This was developed as part of my **master’s thesis**, which focuses on evaluating the security of open-source software for satellite systems. Although designed as a PoC, it has reached ~78% code coverage and already helped uncover multiple vulnerabilities (`CVE-2025-29909`, `CVE-2025-29910`, `CVE-2025-29911`, `CVE-2025-29912`, `CVE-2025-29913` ).

- The implementation needs some improvements to be extended or integrated into a CI/CD pipeline with further performance and coverage optimizations.
