### PR TITLE
Fix reference to SDSL standard

### DIFF
--- a/src/core/crypto_aos.c
+++ b/src/core/crypto_aos.c
@@ -1440,7 +1440,7 @@ int32_t Crypto_Get_aosLength(int len)
  * @param aad: uint8_t*
  * @return status: uint32_t
  *
- * CCSDS Compliance: CCSDS 355.0-B-2 Section 7.2.3 (AAD Construction)
+ * CCSDS Compliance: CCSDS 355.0-B-2 Section 4.2.3 (AAD Construction)
  **/
 uint32_t Crypto_Prepare_AOS_AAD(const uint8_t *buffer, uint16_t len_aad, const uint8_t *abm_buffer, uint8_t *aad)
 {


### PR DESCRIPTION
The chapter describing the AAD construction in CCSDS 355.0-B-2 is 4.2.3 not 7.2.3 (this last one does not exist)

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/nasa/CryptoLib/blob/main/doc/CryptoLib_Indv_CLA.pdf) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/cryptolib/pulls) for the same update/change?

### New Feature Submissions:

* [ ] Does your submission pass tests?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?

### How do you test these changes?

<input type="text" id="explain" name="explain"/>