### PR TITLE
ci: pin third-party Actions to commit SHAs (CWE-829)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,8 @@ jobs:
     #   run: make gcov
 
     - name: Upload 
-      uses: codecov/codecov-action@v5
+      # audit-note:cloud-006-gha-third-party-no-sha — Pin to a 40-char commit SHA. Tag refs are mutable and a repo takeover compromises every workflow using @v1.
+      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: 'coverage/*.c.gcov'
@@ -149,7 +150,8 @@ jobs:
     #   run: make gcov
 
     - name: Upload 
-      uses: codecov/codecov-action@v4
+      # audit-note:cloud-006-gha-third-party-no-sha — Pin to a 40-char commit SHA. Tag refs are mutable and a repo takeover compromises every workflow using @v1.
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: 'coverage/*.c.gcov'
@@ -202,7 +204,8 @@ jobs:
       run: source ~/.bashrc && make gcov
 
     - name: Upload 
-      uses: codecov/codecov-action@v4
+      # audit-note:cloud-006-gha-third-party-no-sha — Pin to a 40-char commit SHA. Tag refs are mutable and a repo takeover compromises every workflow using @v1.
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: 'coverage/*.c.gcov'
@@ -235,7 +238,8 @@ jobs:
     #   run: make gcov
 
     - name: Upload 
-      uses: codecov/codecov-action@v4
+      # audit-note:cloud-006-gha-third-party-no-sha — Pin to a 40-char commit SHA. Tag refs are mutable and a repo takeover compromises every workflow using @v1.
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: 'coverage/*.c.gcov'

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -14,7 +14,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y clang-format
 
       - name: Run Linter
-        uses: DoozyX/clang-format-lint-action@v0.15
+        # audit-note:cloud-006-gha-third-party-no-sha — Pin to a 40-char commit SHA. Tag refs are mutable and a repo takeover compromises every workflow using @v1.
+        uses: DoozyX/clang-format-lint-action@c71d0bf4e21876ebec3e5647491186f8797fde31 # v0.15
         with:
           source: '.'
           extensions: 'c,h'
@@ -23,7 +24,8 @@ jobs:
           inplace: true
 
       - name: Auto-Commit Formatting Changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        # audit-note:cloud-006-gha-third-party-no-sha — Pin to a 40-char commit SHA. Tag refs are mutable and a repo takeover compromises every workflow using @v1.
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
         with:
           commit_message: 'style: auto-format via clang-format'
           


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions in `.github/workflows/` to immutable
40-character commit SHAs, addressing [CWE-829: Inclusion of Functionality
from Untrusted Control Sphere](https://cwe.mitre.org/data/definitions/829.html).

## Why

A third-party Action pinned to a mutable tag (`@v5`, `@v4`, `@master`,
etc.) executes whatever the upstream maintainer pushes to that tag at
workflow run time. A maintainer-account compromise or a malicious tag
rewrite causes the action to run attacker code with `${{ secrets.* }}`
in scope.

The **March 2025 tj-actions/changed-files** supply-chain incident
([CVE-2025-30066](https://nvd.nist.gov/vuln/detail/CVE-2025-30066)) was
exactly this shape: 23,000+ workflows compromised because they used
`@v45` instead of a SHA. GitHub's own hardening guidance explicitly
recommends SHA pinning for third-party Actions:
[Security hardening for GitHub Actions — using third-party actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

## Changes

| File | Action | Before | After |
|---|---|---|---|
| `.github/workflows/build.yml:56` | codecov/codecov-action | `@v5` | `@<sha> # v5` |
| `.github/workflows/build.yml:152` | codecov/codecov-action | `@v4` | `@<sha> # v4` |
| `.github/workflows/build.yml:205` | codecov/codecov-action | `@v4` | `@<sha> # v4` |
| `.github/workflows/build.yml:238` | codecov/codecov-action | `@v4` | `@<sha> # v4` |
| `.github/workflows/cpp-linter.yml:17` | DoozyX/clang-format-lint-action | `@v0.15` | `@<sha> # v0.15` |
| `.github/workflows/cpp-linter.yml:26` | stefanzweifel/git-auto-commit-action | `@v5` | `@<sha> # v5` |

Each SHA was resolved via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>`
against the tag that was previously in use. The human-readable version is
preserved as an inline comment so dependabot / human reviewers can still
see what version is pinned.

NASA actions (`actions/*`, `github/*`) are not touched because they're
GitHub-published and outside the third-party threat model.

## Test plan

- [ ] CI workflows continue to run successfully against the pinned SHAs.
- [ ] Action behavior is identical (the SHAs resolved correspond to the
      tags previously in use; nothing functionally changes).
- [ ] Future Dependabot bumps will need to come as SHA bumps with version
      comment updates — this is the recommended posture.

## Provenance

Discovered by [Kulvex Code (KCode)](https://github.com/AstrolexisAI/KCode),
a deterministic SAST scanner. Pattern: `cloud-006-gha-third-party-no-sha`.

Per common AI-assist disclosure practice: **AI tooling was used.** Discovery
ran through KCode with deterministic regex+AST patterns and an LLM verifier
(Grok 4 Fast). Fix generation ran through KCode's agentic mode with Grok
4.2 reasoning + Claude Sonnet 4.5 fallback. Each SHA resolution was done
by `gh api` calls, not invented.

— Bruno Aiub · AstroLexis · Kulvex Code · contact@astrolexis.space
