### PR TITLE
sa_get_from_spi: reject SAs where shivf_len > iv_len (sibling of arsn/shsnf guard)

### DIFF
--- a/include/crypto_error.h
+++ b/include/crypto_error.h
@@ -158,8 +158,9 @@
 #define CRYPTO_LIB_ERR_SHPLF_LEN_LESS_THAN_MIN_PAD_SIZE                     (-83)
 #define CRYPTO_LIB_ERR_INVALID_AOS_IZ_LENGTH                                (-84)
 #define CRYPTO_LIB_ERR_INVALID_AOS_FRAME_LENGTH                             (-85)
+#define CRYPTO_LIB_ERR_SHIVF_LEN_GREATER_THAN_IV_LEN                        (-86)
 
-#define CRYPTO_CORE_ERROR_CODES_MAX -85
+#define CRYPTO_CORE_ERROR_CODES_MAX -86
 
 // Define codes for returning MDB Strings, and determining error based on strings
 #define CAM_ERROR_CODES     600

--- a/src/core/crypto_error.c
+++ b/src/core/crypto_error.c
@@ -115,7 +115,8 @@ char *crypto_enum_errlist_core[] = {(char *)"CRYPTO_LIB_SUCCESS",
                                     (char *)"CRYPTO_LIB_ERR_TC_FRAME_LENGTH_MISMATCH",
                                     (char *)"CRYPTO_LIB_ERR_SHPLF_LEN_LESS_THAN_MIN_PAD_SIZE",
                                     (char *)"CRYPTO_LIB_ERR_INVALID_AOS_IZ_LENGTH",
-                                    (char *)"CRYPTO_LIB_ERR_INVALID_AOS_FRAME_LENGTH"};
+                                    (char *)"CRYPTO_LIB_ERR_INVALID_AOS_FRAME_LENGTH",
+                                    (char *)"CRYPTO_LIB_ERR_SHIVF_LEN_GREATER_THAN_IV_LEN"};
 
 char *crypto_enum_errlist_config[] = {
     (char *)"CRYPTO_CONFIGURATION_NOT_COMPLETE",

--- a/src/sa/internal/sa_interface_inmemory.template.c
+++ b/src/sa/internal/sa_interface_inmemory.template.c
@@ -781,6 +781,19 @@ static int32_t sa_get_from_spi(uint16_t spi, SecurityAssociation_t **security_as
         return status;
     }
 
+    // IV length cannot be less than the transmitted-IV-field (shivf) length.
+    // Parallel invariant to the shsnf/arsn check above — without this guard,
+    // a loaded SA with shivf_len > iv_len causes `for (i = iv_len - shivf_len;
+    // i < iv_len; i++)` in the per-frame IV walks (crypto_aos.c:318/351/697,
+    // crypto_tc.c:331/631, etc.) to start at a negative index, leaking up to
+    // shivf_len bytes from before sa_ptr->iv into the transmitted frame.
+    if (sa[spi].shivf_len > sa[spi].iv_len)
+    {
+        status = CRYPTO_LIB_ERR_SHIVF_LEN_GREATER_THAN_IV_LEN;
+        mc_if->mc_log(status);
+        return status;
+    }
+
 #ifdef SA_DEBUG
     printf(KYEL "DEBUG - Printing local copy of SA Entry for current SPI.\n" RESET);
     Crypto_saPrint(*security_association);


### PR DESCRIPTION
## Summary

Adds the parallel `iv_len >= shivf_len` invariant check to `sa_get_from_spi` alongside the existing `arsn_len >= shsnf_len` check on line 777. Without this, an SA loaded with `shivf_len > iv_len` makes the IV-walk loops at `crypto_aos.c:318/351/697` and `crypto_tc.c:331/631` start at a negative index and copy pre-iv struct bytes into every transmitted frame. Closes #512.

## Diff

```
 include/crypto_error.h                           |  3 ++-
 src/core/crypto_error.c                          |  3 ++-
 src/sa/internal/sa_interface_inmemory.template.c | 13 +++++++++++++
 3 files changed, 17 insertions(+), 2 deletions(-)
```

The new error code is `CRYPTO_LIB_ERR_SHIVF_LEN_GREATER_THAN_IV_LEN (-86)`, registered in both the header definition and the name-table in `src/core/crypto_error.c` (so `Crypto_Get_Error_Code_Enum_String` prints it correctly).

## Tests

- Constructed an inmemory SA with `shivf_len=20, iv_len=12` (existing `IV_SIZE` allows shivf up to `IV_SIZE` so the existing `sa_verify_data` max check doesn't catch this), called `sa_get_from_spi` on that SPI; **before** this fix the lookup succeeds and `Crypto_TC_ApplySecurity` later leaks 8 bytes per frame; **after** this fix the lookup returns `-86` (`CRYPTO_LIB_ERR_SHIVF_LEN_GREATER_THAN_IV_LEN`).
- Existing test fixtures (where `shivf_len <= iv_len`) continue to pass.

## Scope

The mariadb backend (`src/sa/mariadb/sa_interface_mariadb.template.c`) accepts the same SAs without checking either invariant. Adding the same two-line guard there is a good follow-up; left out of this PR to keep the change small.

## Linked

Closes #512.
