### PR TITLE
Fix authentication-only SAs incorrectly using the encryption cipher

### DIFF
--- a/src/core/crypto_tc.c
+++ b/src/core/crypto_tc.c
@@ -97,9 +97,11 @@ int32_t Crypto_TC_Get_Ciper_Mode_TCA(uint8_t sa_service_type, uint32_t *encrypti
 {
     int32_t status = CRYPTO_LIB_SUCCESS;
 
+    *ecs_is_aead_algorithm = CRYPTO_FALSE;
+
     if (sa_service_type != SA_PLAINTEXT)
     {
-        if (sa_ptr->ecs != CRYPTO_CIPHER_NONE)
+        if (sa_ptr->est == 1 && sa_ptr->ecs != CRYPTO_CIPHER_NONE)
         {
             *encryption_cipher = sa_ptr->ecs;
 #ifdef TC_DEBUG
@@ -1886,10 +1888,15 @@ uint32_t Crypto_TC_Sanity_Validations(TC_t *tc_sdls_processed_frame, SecurityAss
 void Crypto_TC_Get_Ciper_Mode_TCP(uint8_t sa_service_type, uint32_t *encryption_cipher, uint8_t *ecs_is_aead_algorithm,
                                   SecurityAssociation_t *sa_ptr)
 {
-    if (sa_service_type != SA_PLAINTEXT)
+    if (sa_service_type != SA_PLAINTEXT && sa_ptr->est == 1)
     {
         *encryption_cipher     = sa_ptr->ecs;
         *ecs_is_aead_algorithm = Crypto_Is_AEAD_Algorithm(*encryption_cipher);
+    }
+    else
+    {
+        *encryption_cipher     = CRYPTO_CIPHER_NONE;
+        *ecs_is_aead_algorithm = CRYPTO_FALSE;
     }
 }
 

--- a/test/unit/ut_tc_apply.c
+++ b/test/unit/ut_tc_apply.c
@@ -281,6 +281,58 @@ UTEST(TC_APPLY_SECURITY, HAPPY_PATH_AUTH_ENC)
 }
 
 /**
+ * @brief Unit Test: Nominal Authentication Only, ecs Also Populated
+ **/
+UTEST(TC_APPLY_SECURITY, HAPPY_PATH_AUTH_ONLY_ECS_SET)
+{
+    remove("sa_save_file.bin");
+    // Setup & Initialize CryptoLib
+    Crypto_Init_TC_Unit_Test();
+    char       *raw_tc_sdls_ping_h   = "20030015000080d2c70008197f0b00310000b1fe3128";
+    char       *raw_tc_sdls_ping_b   = NULL;
+    int         raw_tc_sdls_ping_len = 0;
+    SaInterface sa_if                = get_sa_interface_inmemory();
+
+    hex_conversion(raw_tc_sdls_ping_h, &raw_tc_sdls_ping_b, &raw_tc_sdls_ping_len);
+
+    uint8_t *ptr_enc_frame = NULL;
+    uint16_t enc_frame_len = 0;
+
+    int32_t return_val = CRYPTO_LIB_ERROR;
+
+    SecurityAssociation_t *test_association;
+    int                    process_len;
+    TC_t                   tc_sdls_processed_frame;
+
+    // Expose the SADB Security Association for test edits.
+    sa_if->sa_get_from_spi(1, &test_association);
+    test_association->sa_state = SA_NONE;
+    sa_if->sa_get_from_spi(3, &test_association);
+    test_association->sa_state  = SA_OPERATIONAL;
+    test_association->abm_len   = ABM_SIZE;
+    test_association->shivf_len = 0;
+    test_association->iv_len    = 0;
+    test_association->acs       = CRYPTO_MAC_HMAC_SHA256;
+    test_association->ecs_len   = 1;
+    test_association->ecs       = CRYPTO_CIPHER_AES256_GCM;
+
+    return_val =
+        Crypto_TC_ApplySecurity((uint8_t *)raw_tc_sdls_ping_b, raw_tc_sdls_ping_len, &ptr_enc_frame, &enc_frame_len);
+    ASSERT_EQ(CRYPTO_LIB_SUCCESS, return_val);
+
+    sa_if->sa_get_from_spi(3, &test_association);
+    memset(test_association->arsn, 0, test_association->arsn_len);
+    process_len = enc_frame_len;
+    memset(&tc_sdls_processed_frame, 0, sizeof(uint8_t) * TC_SIZE);
+    return_val = Crypto_TC_ProcessSecurity(ptr_enc_frame, &process_len, &tc_sdls_processed_frame);
+    ASSERT_EQ(CRYPTO_LIB_SUCCESS, return_val);
+
+    Crypto_Shutdown();
+    free(raw_tc_sdls_ping_b);
+    free(ptr_enc_frame);
+}
+
+/**
  * @brief Unit Test: Nominal Authorized Encryption With Partial IV Rollover, increment static IV
  **/
 UTEST(TC_APPLY_SECURITY, HAPPY_PATH_APPLY_NONTRANSMITTED_INCREMENTING_IV_ROLLOVER)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/nasa/CryptoLib/blob/main/docs/CryptoLib_Indv_CLA.pdf) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/cryptolib/pulls) for the same update/change?

### New Feature Submissions:

* [x] Does your submission pass tests?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### How do you test these changes?

Added a new unit test that configures an authentication-only SA with ecs still populated, applies security, then processes the resulting frame back through Crypto_TC_ProcessSecurity.

Fixes https://github.com/nasa/CryptoLib/issues/521