### PR TITLE
Fix #519, protect control SA from SA START

### DIFF
--- a/src/sa/internal/sa_interface_inmemory.template.c
+++ b/src/sa/internal/sa_interface_inmemory.template.c
@@ -1023,8 +1023,9 @@ static int32_t sa_get_operational_sa_from_gvcid(uint8_t tfvn, uint16_t scid, uin
 static int32_t sa_start(TC_t *tc_frame)
 {
     // Local variables
-    uint8_t        count = 0;
-    uint16_t       spi   = 0x0000;
+    uint8_t        count       = 0;
+    uint16_t       spi         = 0x0000;
+    uint16_t       control_spi = 0x0000;
     crypto_gvcid_t gvcid;
     int            x;
     int            i;
@@ -1033,7 +1034,16 @@ static int32_t sa_start(TC_t *tc_frame)
     printf("\nParsed GVCID: %d\n", num_gvcid);
 
     // Read ingest
-    spi = ((uint8_t)sdls_frame.tlv_pdu.data[0] << 8) | (uint8_t)sdls_frame.tlv_pdu.data[1];
+    spi         = ((uint8_t)sdls_frame.tlv_pdu.data[0] << 8) | (uint8_t)sdls_frame.tlv_pdu.data[1];
+    control_spi = tc_frame->tc_sec_header.spi;
+
+    if (spi == control_spi)
+    {
+#ifdef DEBUG
+        printf(KRED "ERROR: Cannot modify SA in use\n" RESET);
+#endif
+        return CRYPTO_LIB_ERR_SDLS_EP_WRONG_SPI;
+    }
 
     // Check SPI exists and in 'Keyed' state
     if (spi < NUM_SA)

--- a/test/unit/ut_ep_sa_mgmt.c
+++ b/test/unit/ut_ep_sa_mgmt.c
@@ -683,4 +683,44 @@ UTEST(EP_SA_MGMT, SA_STOP_SELF)
     free(buffer_STOP_b);
 }
 
+UTEST(EP_SA_MGMT, SA_START_SELF)
+{
+    remove("sa_save_file.bin");
+
+    Crypto_Config_CryptoLib(KEY_TYPE_INTERNAL, MC_TYPE_INTERNAL, SA_TYPE_INMEMORY, CRYPTOGRAPHY_TYPE_LIBGCRYPT,
+                            IV_INTERNAL);
+    Crypto_Config_TC(CRYPTO_TC_CREATE_FECF_TRUE, TC_PROCESS_SDLS_PDUS_TRUE, TC_HAS_PUS_HDR,
+                     TC_IGNORE_ANTI_REPLAY_FALSE, TC_IGNORE_SA_STATE_FALSE, TC_UNIQUE_SA_PER_MAP_ID_FALSE,
+                     TC_CHECK_FECF_TRUE, 0x3F, SA_INCREMENT_NONTRANSMITTED_IV_TRUE);
+
+    TCGvcidManagedParameters_t TC_0_Managed_Parameters = {0, 0x0003, 0, TC_NO_FECF, TC_HAS_SEGMENT_HDRS, 31, 1};
+    Crypto_Config_Add_TC_Gvcid_Managed_Parameters(TC_0_Managed_Parameters);
+
+    int status = Crypto_Init();
+    ASSERT_EQ(CRYPTO_LIB_SUCCESS, status);
+    SaInterface sa_if = get_sa_interface_inmemory();
+
+    SecurityAssociation_t *test_association;
+    sa_if->sa_get_from_spi(0, &test_association);
+    test_association->sa_state = SA_OPERATIONAL;
+
+    // Construct the minimum SA START context directly: the PDU targets SPI 0,
+    // and SPI 0 is also the SA protecting the control frame.
+    memset(&sdls_frame, 0, sizeof(sdls_frame));
+    sdls_frame.tlv_pdu.hdr.pdu_len = 0x0060;
+    sdls_frame.tlv_pdu.data[0]     = 0x00;
+    sdls_frame.tlv_pdu.data[1]     = 0x00;
+
+    TC_t control_frame = {0};
+    control_frame.tc_sec_header.spi = 0;
+
+    status = sa_if->sa_start(&control_frame);
+    ASSERT_EQ(CRYPTO_LIB_ERR_SDLS_EP_WRONG_SPI, status);
+
+    sa_if->sa_get_from_spi(0, &test_association);
+    ASSERT_EQ(SA_OPERATIONAL, test_association->sa_state);
+
+    Crypto_Shutdown();
+}
+
 UTEST_MAIN();


### PR DESCRIPTION
Fixes #519.

Reject SA START when its target SPI is the same Security Association protecting the incoming control frame. This prevents an SDLS-EP command from transitioning the SA that is protecting the control channel carrying that command, and brings `sa_start` into line with the control-SPI protections used by the other SA management operations.

The implementation compares the selected target SA SPI with `TC_t->tc_sec_header.spi` and returns `CRYPTO_LIB_ERR_SDLS_EP_WRONG_SPI` before the state transition when they match.

Regression coverage adds `SA_START_SELF` through the public SA interface. The test targets the in-use control SA, verifies `sa_start()` returns `CRYPTO_LIB_ERR_SDLS_EP_WRONG_SPI`, and then verifies that the same SA remains operational by successfully applying TC security afterwards.

### All Submissions

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/nasa/CryptoLib/blob/main/docs/CryptoLib_Indv_CLA.pdf) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/cryptolib/pulls) for the same update/change?

### New Feature Submissions

Not applicable. This is a bug fix.

### Changes to Core Features

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### How do you test these changes?

The regression is implemented as `SA_START_SELF` in `test/unit/ut_crypto/crypto_ep_tests.c`. It constructs the SA START context through the public SA interface, attempts to start the same SPI that protects the incoming control frame, checks for `CRYPTO_LIB_ERR_SDLS_EP_WRONG_SPI`, and confirms the protected SA remains usable afterwards.

The current signed-off head has not yet received an upstream or fork CI run, and GitHub currently reports no PR checks, so no passing CI result is claimed yet.