### PR TITLE
Fix #518, return SA transition failures

### DIFF
--- a/src/sa/internal/sa_interface_inmemory.template.c
+++ b/src/sa/internal/sa_interface_inmemory.template.c
@@ -1023,7 +1023,8 @@ static int32_t sa_get_operational_sa_from_gvcid(uint8_t tfvn, uint16_t scid, uin
 static int32_t sa_start(TC_t *tc_frame)
 {
     // Local variables
-    uint8_t        count = 0;
+    int32_t        status = CRYPTO_LIB_SUCCESS;
+    uint8_t        count  = 0;
     uint16_t       spi   = 0x0000;
     crypto_gvcid_t gvcid;
     int            x;
@@ -1151,6 +1152,7 @@ static int32_t sa_start(TC_t *tc_frame)
 #ifdef DEBUG
             printf(KRED "ERROR: SPI %d is not in the KEYED state.\n" RESET, spi);
 #endif
+            status = CRYPTO_LIB_ERROR;
         }
     }
     else
@@ -1158,13 +1160,14 @@ static int32_t sa_start(TC_t *tc_frame)
 #ifdef DEBUG
         printf(KRED "ERROR: SPI %d does not exist.\n" RESET, spi);
 #endif
+        status = CRYPTO_LIB_ERR_SPI_INDEX_OOB;
     }
 
 #ifdef DEBUG
     printf("\t spi = %d \n", spi);
 #endif
 
-    return CRYPTO_LIB_SUCCESS;
+    return status;
 }
 
 /**
@@ -1334,6 +1337,7 @@ static int32_t sa_rekey(TC_t *tc_frame)
 #ifdef PDU_DEBUG
             printf(KRED "ERROR: SPI %d is not in the UNKEYED state.\n" RESET, spi);
 #endif
+            status = CRYPTO_LIB_ERROR;
         }
     }
     else
@@ -1341,14 +1345,18 @@ static int32_t sa_rekey(TC_t *tc_frame)
 #ifdef PDU_DEBUG
         printf(KRED "ERROR: SPI %d does not exist.\n" RESET, spi);
 #endif
+        status = CRYPTO_LIB_ERR_SPI_INDEX_OOB;
     }
 
 #ifdef PDU_DEBUG
     printf("\t spi  = %d \n", spi);
-    printf("\t ekid = %d \n", sa[spi].ekid);
+    if (spi < NUM_SA)
+    {
+        printf("\t ekid = %d \n", sa[spi].ekid);
+    }
 #endif
 
-    return CRYPTO_LIB_SUCCESS;
+    return status;
 }
 
 /**
@@ -1399,6 +1407,7 @@ static int32_t sa_expire(TC_t *tc_frame)
 #ifdef DEBUG
             printf(KRED "ERROR: SPI %d is not in the KEYED state.\n" RESET, spi);
 #endif
+            status = CRYPTO_LIB_ERROR;
         }
     }
     else
@@ -1406,9 +1415,10 @@ static int32_t sa_expire(TC_t *tc_frame)
 #ifdef DEBUG
         printf(KRED "ERROR: SPI %d does not exist.\n" RESET, spi);
 #endif
+        status = CRYPTO_LIB_ERR_SPI_INDEX_OOB;
     }
 
-    return CRYPTO_LIB_SUCCESS;
+    return status;
 }
 
 /**

--- a/test/unit/ut_crypto.c
+++ b/test/unit/ut_crypto.c
@@ -178,7 +178,7 @@ UTEST(CRYPTO_C, PDU_SWITCH)
 
     sdls_frame.tlv_pdu.hdr.pid = PID_START_SA;
     status                     = Crypto_PDU(ingest, &tc_frame);
-    ASSERT_EQ(status, CRYPTO_LIB_SUCCESS);
+    ASSERT_EQ(status, CRYPTO_LIB_ERROR);
 
     sdls_frame.tlv_pdu.hdr.pid = PID_STOP_SA;
     status                     = Crypto_PDU(ingest, &tc_frame);

--- a/test/unit/ut_ep_sa_mgmt.c
+++ b/test/unit/ut_ep_sa_mgmt.c
@@ -683,4 +683,66 @@ UTEST(EP_SA_MGMT, SA_STOP_SELF)
     free(buffer_STOP_b);
 }
 
+
+UTEST(EP_SA_MGMT, SA_TRANSITION_ERROR_CODES)
+{
+    remove("sa_save_file.bin");
+
+    Crypto_Config_CryptoLib(KEY_TYPE_INTERNAL, MC_TYPE_INTERNAL, SA_TYPE_INMEMORY, CRYPTOGRAPHY_TYPE_LIBGCRYPT,
+                            IV_INTERNAL);
+    Crypto_Config_TC(CRYPTO_TC_CREATE_FECF_TRUE, TC_PROCESS_SDLS_PDUS_TRUE, TC_HAS_PUS_HDR,
+                     TC_IGNORE_ANTI_REPLAY_FALSE, TC_IGNORE_SA_STATE_FALSE, TC_UNIQUE_SA_PER_MAP_ID_FALSE,
+                     TC_CHECK_FECF_TRUE, 0x3F, SA_INCREMENT_NONTRANSMITTED_IV_TRUE);
+
+    TCGvcidManagedParameters_t managed_parameters = {0, 0x0003, 0, TC_NO_FECF, TC_HAS_SEGMENT_HDRS, 31, 1};
+    Crypto_Config_Add_TC_Gvcid_Managed_Parameters(managed_parameters);
+
+    int32_t status = Crypto_Init();
+    ASSERT_EQ(CRYPTO_LIB_SUCCESS, status);
+
+    SaInterface             sa_if = get_sa_interface_inmemory();
+    SecurityAssociation_t *target_sa;
+    TC_t                    control_frame = {0};
+    control_frame.tc_sec_header.spi = 0;
+
+    memset(&sdls_frame, 0, sizeof(sdls_frame));
+    sdls_frame.tlv_pdu.hdr.pdu_len = 16;
+    sdls_frame.tlv_pdu.data[0]     = 0x00;
+    sdls_frame.tlv_pdu.data[1]     = 0x06;
+
+    // START requires KEYED.
+    sa_if->sa_get_from_spi(6, &target_sa);
+    target_sa->sa_state = SA_OPERATIONAL;
+    status              = sa_if->sa_start(&control_frame);
+    ASSERT_EQ(CRYPTO_LIB_ERROR, status);
+    ASSERT_EQ(SA_OPERATIONAL, target_sa->sa_state);
+
+    // REKEY requires UNKEYED.
+    target_sa->sa_state = SA_KEYED;
+    status              = sa_if->sa_rekey(&control_frame);
+    ASSERT_EQ(CRYPTO_LIB_ERROR, status);
+    ASSERT_EQ(SA_KEYED, target_sa->sa_state);
+
+    // EXPIRE requires KEYED.
+    target_sa->sa_state = SA_OPERATIONAL;
+    status              = sa_if->sa_expire(&control_frame);
+    ASSERT_EQ(CRYPTO_LIB_ERROR, status);
+    ASSERT_EQ(SA_OPERATIONAL, target_sa->sa_state);
+
+    // All three operations must reject an SPI outside the SA table.
+    sdls_frame.tlv_pdu.data[0] = (NUM_SA >> BYTE_LEN) & 0xFF;
+    sdls_frame.tlv_pdu.data[1] = NUM_SA & 0xFF;
+
+    status = sa_if->sa_start(&control_frame);
+    ASSERT_EQ(CRYPTO_LIB_ERR_SPI_INDEX_OOB, status);
+
+    status = sa_if->sa_rekey(&control_frame);
+    ASSERT_EQ(CRYPTO_LIB_ERR_SPI_INDEX_OOB, status);
+
+    status = sa_if->sa_expire(&control_frame);
+    ASSERT_EQ(CRYPTO_LIB_ERR_SPI_INDEX_OOB, status);
+
+    Crypto_Shutdown();
+}
+
 UTEST_MAIN();


### PR DESCRIPTION
Return explicit failures from SA START, REKEY, and EXPIRE when the target SA is in the wrong state or the requested SPI is outside the SA table instead of silently reporting success.

Use CRYPTO_LIB_ERROR for invalid transition state, matching existing SA management behavior, and CRYPTO_LIB_ERR_SPI_INDEX_OOB for an invalid SPI. Also guard the REKEY debug-only EKID access so an out-of-range SPI cannot be dereferenced when PDU debugging is enabled.

Add focused regression coverage for invalid-state and out-of-range START, REKEY, and EXPIRE operations, and update the PDU dispatch test to expect the newly surfaced START failure.

Validation: CryptoLib extended-procedure build and full EP test suite pass in the project container; git diff --check passes.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/nasa/CryptoLib/blob/main/docs/CryptoLib_Indv_CLA.pdf) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/nasa/cryptolib/pulls) for the same update/change?

### New Feature Submissions:

* [ ] Does your submission pass tests?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?

### How do you test these changes?

