### PR TITLE
Fix #497, correct KMC length outputs

### DIFF
--- a/src/crypto/kmc/cryptography_interface_kmc_crypto_service.template.c
+++ b/src/crypto/kmc/cryptography_interface_kmc_crypto_service.template.c
@@ -528,7 +528,7 @@ static int32_t cryptography_decrypt(uint8_t *data_out, size_t len_data_out, uint
     // TODO -- Parse the key length from the keyInfo endpoint of the Crypto Service!
     uint32_t key_len_in_bits         = len_key * 8; // 8 bits per byte.
     uint32_t key_len_in_bits_str_len = 0;
-    char    *key_len_in_bits_str     = int_to_str(key_len_in_bits, &key_len_in_bits);
+    char    *key_len_in_bits_str     = int_to_str(key_len_in_bits, &key_len_in_bits_str_len);
 
     curl_easy_reset(curl);
     status = configure_curl_connect_opts(curl, cam_cookies);
@@ -1662,7 +1662,7 @@ static int32_t cryptography_aead_decrypt(uint8_t *data_out, size_t len_data_out,
     // TODO -- Parse the key length from the keyInfo endpoint of the Crypto Service!
     uint32_t key_len_in_bits         = len_key * 8; // 8 bits per byte.
     uint32_t key_len_in_bits_str_len = 0;
-    char    *key_len_in_bits_str     = int_to_str(key_len_in_bits, &key_len_in_bits);
+    char    *key_len_in_bits_str     = int_to_str(key_len_in_bits, &key_len_in_bits_str_len);
 
     curl_easy_reset(curl);
     status = configure_curl_connect_opts(curl, cam_cookies);


### PR DESCRIPTION
Fixes #497.

Correct both KMC decrypt-path calls to `int_to_str()` so the converted key-length string size is written to `key_len_in_bits_str_len`. The existing endpoint buffer-size calculation already consumes that variable; the wrong output pointer leaves it at zero.

Scope:
- two output-pointer corrections in `cryptography_interface_kmc_crypto_service.template.c`
- no API or protocol change
- one clean commit based on current `dev`

Validation:
- exactly two affected calls corrected
- no erroneous `int_to_str(key_len_in_bits, &key_len_in_bits)` occurrence remains in the file
