### PR TITLE
Return error status for unrecognized PDU PIDs and service groups

### DIFF
--- a/include/crypto_error.h
+++ b/include/crypto_error.h
@@ -164,8 +164,9 @@
 #define CRYPTO_LIB_ERR_TM_FL_GT_MAX_FRAME_SIZE                              (-89)
 #define CRYPTO_LIB_ERR_TM_APPLY_PADDING                                     (-90)
 #define CRYPTO_LIB_ERR_BUFFER_SIZE                                          (-91)
+#define CRYPTO_LIB_ERR_INVALID_PID                                          (-92)
 
-#define CRYPTO_CORE_ERROR_CODES_MAX -91
+#define CRYPTO_CORE_ERROR_CODES_MAX -92
 
 // Define codes for returning MDB Strings, and determining error based on strings
 #define CAM_ERROR_CODES     600

--- a/src/core/crypto.c
+++ b/src/core/crypto.c
@@ -607,6 +607,7 @@ int32_t Crypto_PDU(uint8_t *ingest, TC_t *tc_frame)
 #ifdef PDU_DEBUG
                                 printf(KRED "Error: Crypto_PDU failed interpreting Service Group! \n" RESET);
 #endif
+                                status = CRYPTO_LIB_ERR_INVALID_PID;
                                 break;
                         }
                         break;
@@ -626,6 +627,7 @@ int32_t Crypto_PDU(uint8_t *ingest, TC_t *tc_frame)
 #ifdef PDU_DEBUG
                 printf(KRED "Error: Crypto_PDU failed interpreting PDU Type!  Received a Reply!?! \n" RESET);
 #endif
+                status = CRYPTO_LIB_ERROR;
                 break;
         }
     }
@@ -687,6 +689,7 @@ int32_t Crypto_SG_KEY_MGMT(uint8_t *ingest, TC_t *tc_frame)
             printf(KRED
                    "Error: Crypto_PDU failed interpreting Key Management Procedure Identification Field! \n" RESET);
 #endif
+            status = CRYPTO_LIB_ERR_INVALID_PID;
             break;
     }
     return status;
@@ -770,6 +773,7 @@ int32_t Crypto_SG_SA_MGMT(uint8_t *ingest, TC_t *tc_frame)
 #ifdef PDU_DEBUG
             printf(KRED "Error: Crypto_PDU failed interpreting SA Procedure Identification Field! \n" RESET);
 #endif
+            status = CRYPTO_LIB_ERR_INVALID_PID;
             break;
     }
     return status;
@@ -828,6 +832,7 @@ int32_t Crypto_SEC_MON_CTRL(uint8_t *ingest)
 #ifdef PDU_DEBUG
             printf(KRED "Error: Crypto_PDU failed interpreting MC Procedure Identification Field! \n" RESET);
 #endif
+            status = CRYPTO_LIB_ERR_INVALID_PID;
             break;
     }
     return status;

--- a/src/core/crypto_error.c
+++ b/src/core/crypto_error.c
@@ -121,7 +121,8 @@ char *crypto_enum_errlist_core[] = {(char *)"CRYPTO_LIB_SUCCESS",
                                     (char *)"CRYPTO_LIB_ERR_AOS_FL_GT_MAX_FRAME_SIZE",
                                     (char *)"CRYPTO_LIB_ERR_TM_FL_GT_MAX_FRAME_SIZE",
                                     (char *)"CRYPTO_LIB_ERR_TM_APPLY_PADDING",
-                                    (char *)"CRYPTO_LIB_ERR_BUFFER_SIZE"};
+                                    (char *)"CRYPTO_LIB_ERR_BUFFER_SIZE",
+                                    (char *)"CRYPTO_LIB_ERR_INVALID_PID"};
 
 char *crypto_enum_errlist_config[] = {
     (char *)"CRYPTO_CONFIGURATION_NOT_COMPLETE",


### PR DESCRIPTION
Fixes #535

## Summary

The PDU dispatch functions initialized `status` to `CRYPTO_LIB_SUCCESS` and never assigned it in their `default:` branches, so a malformed or unsupported command was silently reported as success - the library printed "failed interpreting ... Identification Field!" while returning `Status code: 0`.

## Changes

- Added `CRYPTO_LIB_ERR_INVALID_PID` (-92) to `crypto_error.h`, its entry in `crypto_enum_errlist_core[]`, and bumped `CRYPTO_CORE_ERROR_CODES_MAX` so error-string lookups stay in bounds
- `Crypto_SG_SA_MGMT`: default branch now returns the new code (the exact case from the issue's reproduction, pid=0x8)
- `Crypto_SG_KEY_MGMT` and `Crypto_SEC_MON_CTRL`: same copy-pasted shape fixed as the issue suggested ("worth checking whether the sibling dispatch functions have the same shape" - they did)
- `Crypto_PDU`: the unrecognized-service-group default now returns `CRYPTO_LIB_ERR_INVALID_PID`, and the `PDU_TYPE_REPLY` case (a command PDU carrying a reply type) returns `CRYPTO_LIB_ERROR` instead of success

## Testing

- [x] Verified all four fall-through-to-success sites on current `dev` before changing
- [x] Error-string table stays index-aligned: array has entries 0..92 matching codes 0..-92
- [ ] Local build not run (no C toolchain in this environment); requesting CI run. The reproduction sequence from the issue (`sg=0x1, pid=0x8`) should now yield `Status code: -92` / `CRYPTO_LIB_ERR_INVALID_PID`
